### PR TITLE
Enhance footer server status parsing and UI adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@eslint/js": "^9.31.0",
     "@types/bootstrap": "^5.2.10",
     "@types/luxon": "^3.6.2",
-    "@types/node": "^24.0.13",
+    "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,12 +1106,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^24.0.13":
-  version: 24.0.13
-  resolution: "@types/node@npm:24.0.13"
+"@types/node@npm:^24.0.14":
+  version: 24.0.14
+  resolution: "@types/node@npm:24.0.14"
   dependencies:
     undici-types: "npm:~7.8.0"
-  checksum: 10c0/e1f3d4ea8973b1f2f987814ac5343d05ad8b56bf7fa41755295dee0ce0f7b4e2de4f3daef5296429180228970cef0d70f2ad873c61dbafc6f5eeca9d023aba76
+  checksum: 10c0/536b5a816554ad1522e9e0c1d517b317f8478798bd76a332d83690aa42b19b5b263eb295ee25f9d0badb430ee6e36412ee9070cb5e3359f6bdcf7e08f94302f1
   languageName: node
   linkType: hard
 
@@ -5038,7 +5038,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:^2.8.2"
     "@types/bootstrap": "npm:^5.2.10"
     "@types/luxon": "npm:^3.6.2"
-    "@types/node": "npm:^24.0.13"
+    "@types/node": "npm:^24.0.14"
     "@types/react": "npm:^19.1.8"
     "@types/react-dom": "npm:^19.1.6"
     "@vitejs/plugin-react": "npm:^4.6.0"


### PR DESCRIPTION
- Add `stripPrefix` helper to clean server names in `Footer.tsx`
- Update server status handling to use cleaned names in `Footer.tsx`
- Filter and reorganize server lists into US/EU and Legacy sections
- Adjust container alignment and text centering in footer display
- Upgrade `@types/node` from `24.0.13` to `24.0.14` in `package.json`
- Synchronize `yarn.lock` to reflect updated `@types/node` version