### PR TITLE
Refactor: Update typing and ingredient logic in crafting components

### DIFF
--- a/src/components/timer/Countdown.tsx
+++ b/src/components/timer/Countdown.tsx
@@ -1,5 +1,4 @@
 import { DateTime, Duration } from 'luxon'
-import type { Valid } from 'luxon/src/_util'
 import { useEffect, useState } from 'react'
 
 const Countdown = (props: Props) => {
@@ -9,9 +8,9 @@ const Countdown = (props: Props) => {
 
   useEffect(() => {
     const updateRemainingTime = () => {
-      const now: DateTime<Valid> = DateTime.now()
-      const targetTime: DateTime<Valid> = DateTime.fromSeconds(targetTimestamp)
-      const diff: Duration<Valid> = targetTime.diff(now, ['days', 'hours', 'minutes', 'seconds'])
+      const now: DateTime = DateTime.now()
+      const targetTime: DateTime = DateTime.fromSeconds(targetTimestamp)
+      const diff: Duration = targetTime.diff(now, ['days', 'hours', 'minutes', 'seconds'])
 
       if (diff.toMillis() <= 0) {
         setRemainingTime(Duration.fromMillis(0))
@@ -44,8 +43,8 @@ const Countdown = (props: Props) => {
 }
 
 const calculateRemainingTime = (targetTimestamp: number): Duration => {
-  const now: DateTime<Valid> = DateTime.now() // Current time
-  const targetTime: DateTime<Valid> = DateTime.fromSeconds(targetTimestamp) // Target Unix timestamp
+  const now: DateTime = DateTime.now() // Current time
+  const targetTime: DateTime = DateTime.fromSeconds(targetTimestamp) // Target Unix timestamp
   return targetTime.diff(now, ['days', 'hours', 'minutes', 'seconds'])
 }
 

--- a/src/pages/dinosaurBoneCrafting/DinosaurBone.tsx
+++ b/src/pages/dinosaurBoneCrafting/DinosaurBone.tsx
@@ -27,6 +27,7 @@ import {
 import type { AppDispatch } from '../../redux/store.ts'
 import type { AugmentItem } from '../../types/augmentItem.ts'
 import type { CraftingIngredient } from '../../types/crafting.ts'
+import type { Ingredient } from '../../types/ingredients.ts'
 import { camelCaseToTitleCase, getCumulativeIngredients } from '../../utils/utils.ts'
 import CumulativeIngredientsCard from './components/CumulativeIngredientsCard.tsx'
 import ItemDisplay from './components/ItemDisplay.tsx'
@@ -141,7 +142,7 @@ const DinosaurBone = () => {
 
   const augmentOptions = useMemo<Record<string, CraftingIngredient[]>>(() => {
     return availableAugmentSlots.reduce<Record<string, CraftingIngredient[]>>((acc, slot) => {
-      let options: CraftingIngredient[]
+      let options: Ingredient[]
 
       if (slot === 'isleOfDreadSetBonus') {
         options = dinosaurBoneCrafting.filter((ing) => ing.setBonus)


### PR DESCRIPTION
- Add `Ingredient` type import in `DinosaurBone.tsx`.
- Replace `CraftingIngredient` with `Ingredient` in `augmentOptions`.
- Remove unused `Valid` type import from `Countdown.tsx`.
- Fix typings to eliminate `<Valid>` generic usage in `Countdown` logic.