### PR TITLE
Add images and refine augment names in update75

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.8.0",
+    "react-router-dom": "^7.8.1",
     "simple-xml-to-json": "^1.2.3",
     "sitemap": "^8.0.0",
     "title-case": "^4.3.2"
@@ -33,10 +33,10 @@
     "@eslint/js": "^9.33.0",
     "@types/bootstrap": "^5.2.10",
     "@types/luxon": "^3.7.1",
-    "@types/node": "^24.2.1",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
-    "@vitejs/plugin-react": "^5.0.0",
+    "@vitejs/plugin-react": "^5.0.1",
     "eslint": "^9.33.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -46,8 +46,8 @@
     "prettier": "^3.6.2",
     "sass": "^1.90.0",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2",
+    "typescript-eslint": "^8.40.0",
+    "vite": "^7.1.3",
     "vite-plugin-compression": "^0.5.1"
   },
   "packageManager": "yarn@4.9.2"

--- a/src/components/common/FallbackImage.tsx
+++ b/src/components/common/FallbackImage.tsx
@@ -3,7 +3,7 @@ import { Image } from 'react-bootstrap'
 import { ICON_BASE } from '../../utils/constants.ts'
 
 const FallbackImage = (props: Props) => {
-  const { alt, src } = props
+  const { alt, src, width } = props
 
   const [imgSrc, setImgSrc] = useState(src)
 
@@ -15,6 +15,7 @@ const FallbackImage = (props: Props) => {
         setImgSrc(`${ICON_BASE}unknown.png`)
       }}
       alt={alt}
+      style={{ width: width ?? undefined }}
     />
   )
 }
@@ -22,6 +23,7 @@ const FallbackImage = (props: Props) => {
 interface Props {
   src: string
   alt: string
+  width?: string
 }
 
 export default FallbackImage

--- a/src/data/augments/update75.ts
+++ b/src/data/augments/update75.ts
@@ -4,11 +4,11 @@ export const update75Augments: AugmentItem[] = [
   // Legendary Augments
   {
     name: 'Melancholic Flames (ML:34)',
+    image: 'melancholicAugment',
     description: 'Slotted Effect: Adds Adamantine material type. On hit: 16d6 Fire Damage',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
-
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -51,11 +51,11 @@ export const update75Augments: AugmentItem[] = [
   },
   {
     name: 'Melancholic Chill (ML:34)',
+    image: 'melancholicAugment',
     description: 'Slotted Effect: Adds Cold Iron material type. On hit: 16d6 Cold Damage',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
-
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -98,6 +98,7 @@ export const update75Augments: AugmentItem[] = [
   },
   {
     name: 'Melancholic Sparks (ML:34)',
+    image: 'melancholicAugment',
     description: 'Slotted Effect: Adds Silver material type. On hit: 16d6 Electric Damage',
     minimumLevel: 34,
     type: 'Augment',
@@ -145,11 +146,11 @@ export const update75Augments: AugmentItem[] = [
   },
   {
     name: 'Melancholic Acid (ML:34)',
+    image: 'melancholicAugment',
     description: 'Slotted Effect: Adds Crystal and Byeshk material type. On hit: 16d6 Acid Damage',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
-
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -200,7 +201,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -251,7 +252,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -302,7 +303,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -347,13 +348,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Flames (ML:34)',
+    name: 'Dolorous Flames (ML:34)',
     description:
       'Adds Good alignment bypass. Your attacks and spells have a small chance to deal a large amount of Fire damage.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -386,13 +387,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Chill (ML:34)',
+    name: 'Dolorous Chill (ML:34)',
     description:
       'Adds Chaotic alignment bypass. Your attacks and spells have a chance to inflict ten stacks of Cold damage over time.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -425,13 +426,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Sparks (ML:34)',
+    name: 'Dolorous Sparks (ML:34)',
     description:
       'Adds Lawful alignment bypass. Your attacks and spells have a small chance to deal a large amount of Electric damage.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -464,13 +465,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Acid (ML:34)',
+    name: 'Dolorous Acid (ML:34)',
     description:
       'Adds Evil alignment bypass. Your attacks and spells have a small chance to deal a large amount of Acid damage.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -503,12 +504,12 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Dimlight (ML:34)',
+    name: 'Dolorous Dimlight (ML:34)',
     description: 'Your attacks and offensive spells have a chance to deal Untyped damage.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -541,13 +542,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Shadows (ML:34)',
+    name: 'Dolorous Shadows (ML:34)',
     description:
       'Your attacks and offensive spells have a chance to apply a Curse that deals significant Untyped damage over time.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -580,13 +581,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Arcana (ML:34)',
+    name: 'Dolorous Focus (ML:34)',
     description:
       'Slotted Effect: +5 Equipment bonus to all Spell DCs. If this is slotted into a Quarterstaff, also grants a +5% Exceptional bonus to Spell Spell Critical Chance and makes the Quarterstaff an Implement.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -631,12 +632,452 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
+    name: 'Dolorous Arcana: Fire (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Fire Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fire Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Cold (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Cold Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Cold Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Electric (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Electric Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Electric Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Acid (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Acid Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Acid Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Light (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Light and Alignment Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Light and Alignment Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Negative (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Negative and Poison Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Negative and Poison Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Sonic (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Sonic Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sonic Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Force (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Force and Physical Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Force and Physical Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Positive (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Positive Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Positive Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Repair (ML:34)',
+    description: 'Slotted Effect: +79 Insight bonus to Repair Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Repair Spell Power',
+        bonus: 'Insight',
+        modifier: 79
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
     name: 'Miserable Flames (ML:34)',
     description: 'Slotted Effect: +2 Exceptional bonus to Strength.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -684,7 +1125,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -732,7 +1173,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -780,7 +1221,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -828,7 +1269,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -876,7 +1317,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -925,7 +1366,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Weapon)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -975,7 +1416,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Weapon)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1022,7 +1463,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Weapon)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1069,7 +1510,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Weapon)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1118,7 +1559,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Weapon)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1166,7 +1607,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Weapon)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1215,7 +1656,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1263,7 +1704,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1311,7 +1752,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1359,7 +1800,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1407,7 +1848,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1455,7 +1896,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1503,7 +1944,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1551,7 +1992,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1599,7 +2040,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1647,7 +2088,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1690,12 +2131,350 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
+    name: 'Miserable Improved Destruction (ML:34)',
+    description:
+      'Slotted Effect: Your attacks apply a stack of Armor Destruction. (-1 Penalty to Armor Class, -1% of its Fortification. 20 Second Duration. Stacks up to 15 times.) This effect may trigger once every three seconds.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Improved Destruction'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 100
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Maiming (ML:34)',
+    description:
+      'Slotted Effect: Adds Maiming. When you score a critical hit with this weapon, it does an additional +7d8 damage.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Maiming 7'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 100
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Humanoid Bane (ML:34)',
+    description:
+      'Slotted Effect: Adds Humanoid Bane. This weapon is attuned specifically to those that walk among us, dealing an additional 7d10 bane damage vs. Humanoids',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Humanoid Bane 7',
+        bonus: 'On-hit vs Humanoid',
+        modifier: '7d10'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 100
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Monstrous Humanoid Bane (ML:34)',
+    description:
+      'Slotted Effect: Adds Monstrous Humanoid Bane. This weapon is attuned specifically to hunt those who are descended from monsters, dealing an additional 7d10 bane damage vs. Monstrous Humanoids',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Monstrous Humanoid Bane 7',
+        bonus: 'On-hit vs Monstrous Humanoid',
+        modifier: '7d10'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 100
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Vermin Bane (ML:34)',
+    description:
+      'Slotted Effect: Adds Vermin Bane. This weapon is ideal for clearing out rats and other annoying beasts. It deals an additional 7d10 bane damage vs. Vermin',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Vermin Bane 7',
+        bonus: 'On-hit vs Vermin',
+        modifier: '7d10'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 100
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Undead Bane (ML:34)',
+    description:
+      'Slotted Effect: Adds Undead Bane. Those that have died must return, and this weapon is attuned specifically to lay them to rest. This weapon deals an additional 7d10 bane damage vs. Undead',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Undead Bane 7',
+        bonus: 'On-hit vs Undead',
+        modifier: '7d10'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 100
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Armor-Piercing (ML:34)',
+    description: 'Adds Armor-Piercing. +23% Enhancement bonus to Bypass Enemy Fortification.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Bypass Fortification',
+        bonus: 'Enhancement',
+        modifier: '23%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 100
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
     name: 'Melancholic: Strength (ML:34)',
     description: 'Slotted Effect: +15 Enhancement bonus to Strength.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1739,7 +2518,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1783,7 +2562,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1827,7 +2606,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1871,7 +2650,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1915,7 +2694,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -1959,7 +2738,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2003,7 +2782,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2047,7 +2826,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2091,7 +2870,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2135,7 +2914,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2179,7 +2958,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2223,7 +3002,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2267,7 +3046,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2311,7 +3090,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2355,7 +3134,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2399,7 +3178,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2438,12 +3217,100 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
+    name: 'Melancholic: Doublestrike (ML:34)',
+    description: 'Slotted Effect: +17% Enhancement bonus to Doublestrike.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Doublestrike',
+        bonus: 'Enhancement',
+        modifier: '17%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Doubleshot (ML:34)',
+    description: 'Slotted Effect: +9% Enhancement bonus to Doubleshot.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Doubleshot',
+        bonus: 'Enhancement',
+        modifier: '9%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 25
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 25
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
     name: 'Dolorous: Healing Amplification (ML:34)',
     description: 'Slotted Effect: +61 Competence bonus to Positive Healing Amplification.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2487,7 +3354,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2531,7 +3398,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2575,7 +3442,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2619,7 +3486,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2664,7 +3531,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2713,7 +3580,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2762,7 +3629,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2806,7 +3673,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2850,7 +3717,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2894,7 +3761,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2938,7 +3805,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -2982,7 +3849,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3026,7 +3893,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3070,7 +3937,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3114,7 +3981,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3158,7 +4025,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3197,12 +4064,434 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
+    name: 'Dolorous: Quality Strength (ML:34)',
+    description: 'Slotted Effect: +3 Quality bonus to Strength.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Strength',
+        bonus: 'Quality',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Dexterity (ML:34)',
+    description: 'Slotted Effect: +3 Quality bonus to Dexterity.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Dexterity',
+        bonus: 'Quality',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Constitution (ML:34)',
+    description: 'Slotted Effect: +3 Quality bonus to Constitution.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Constitution',
+        bonus: 'Quality',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Intelligence (ML:34)',
+    description: 'Slotted Effect: +3 Quality bonus to Intelligence.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Intelligence',
+        bonus: 'Quality',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Wisdom (ML:34)',
+    description: 'Slotted Effect: +3 Quality bonus to Wisdom.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Wisdom',
+        bonus: 'Quality',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Charisma (ML:34)',
+    description: 'Slotted Effect: +3 Quality bonus to Charisma.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Charisma',
+        bonus: 'Quality',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Accuracy (ML:34)',
+    description: 'Slotted Effect: +5 Quality bonus to Attack.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Attack',
+        bonus: 'Quality',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Damage (ML:34)',
+    description: 'Slotted Effect: ',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Damage',
+        bonus: 'Quality',
+        modifier: 5,
+        notes: ''
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Quality Combat Mastery (ML:34)',
+    description: 'Slotted Effect: ',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Trip DC',
+        bonus: 'Quality',
+        modifier: 3
+      },
+      {
+        name: 'Improved Trip DC',
+        bonus: 'Quality',
+        modifier: 3
+      },
+      {
+        name: 'Sunder DC',
+        bonus: 'Quality',
+        modifier: 3
+      },
+      {
+        name: 'Improved Sunder DC',
+        bonus: 'Quality',
+        modifier: 3
+      },
+      {
+        name: 'Stunning Blow DC',
+        bonus: 'Quality',
+        modifier: 3
+      },
+      {
+        name: 'Stunning Fist DC',
+        bonus: 'Quality',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 50
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 50
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
     name: 'Miserable: Physical Resistance Rating (ML:34)',
     description: 'Slotted Effect: +38 Enhancement bonus to Physical Resistance Rating.',
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3250,7 +4539,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3298,7 +4587,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3346,7 +4635,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3394,7 +4683,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3442,7 +4731,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3490,7 +4779,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3538,7 +4827,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3586,7 +4875,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3634,7 +4923,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3682,7 +4971,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3730,7 +5019,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3778,7 +5067,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3826,7 +5115,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3874,7 +5163,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3922,7 +5211,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -3970,7 +5259,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Accessory)',
-
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4018,7 +5307,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Accessory)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4067,7 +5356,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Accessory)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4114,7 +5403,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Accessory)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4160,7 +5449,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Accessory)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4208,7 +5497,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Accessory)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4256,7 +5545,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Accessory)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4304,7 +5593,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Woeful (Accessory)',
-
+    image: 'woefulAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4352,7 +5641,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Armor)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4401,7 +5690,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Armor)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4459,7 +5748,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Armor)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4508,7 +5797,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Armor)',
-
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4556,7 +5845,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Armor)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4604,7 +5893,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Armor)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4662,7 +5951,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 34,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Armor)',
-
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -4704,853 +5993,6 @@ export const update75Augments: AugmentItem[] = [
     },
     weight: 0.01
   },
-  {
-    name: 'Miserable Improved Destruction (ML:34)',
-    description:
-      'Slotted Effect: Your attacks apply a stack of Armor Destruction. (-1 Penalty to Armor Class, -1% of its Fortification. 20 Second Duration. Stacks up to 15 times.) This effect may trigger once every three seconds.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Improved Destruction'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Maiming (ML:34)',
-    description: '<string table error; tableDID [0x25000013] token [0x0A039775]>',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Maiming 7'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Humanoid Bane (ML:34)',
-    description:
-      'Slotted Effect: Adds Humanoid Bane. This weapon is attuned specifically to those that walk among us, dealing an additional 7d10 bane damage vs. Humanoids',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Humanoid Bane 7',
-        bonus: 'On-hit vs Humanoid',
-        modifier: '7d10'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Monstrous Humanoid Bane (ML:34)',
-    description:
-      'Slotted Effect: Adds Monstrous Humanoid Bane. This weapon is attuned specifically to hunt those who are descended from monsters, dealing an additional 7d10 bane damage vs. Monstrous Humanoids',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Monstrous Humanoid Bane 7',
-        bonus: 'On-hit vs Monstrous Humanoid',
-        modifier: '7d10'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Vermin Bane (ML:34)',
-    description:
-      'Slotted Effect: Adds Vermin Bane. This weapon is ideal for clearing out rats and other annoying beasts. It deals an additional 7d10 bane damage vs. Vermin',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Vermin Bane 7',
-        bonus: 'On-hit vs Vermin',
-        modifier: '7d10'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Undead Bane (ML:34)',
-    description:
-      'Slotted Effect: Adds Undead Bane. Those that have died must return, and this weapon is attuned specifically to lay them to rest. This weapon deals an additional 7d10 bane damage vs. Undead',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Undead Bane 7',
-        bonus: 'On-hit vs Undead',
-        modifier: '7d10'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Armor-Piercing (ML:34)',
-    description: 'Adds Armor-Piercing. +23% Enhancement bonus to Bypass Enemy Fortification.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Bypass Fortification',
-        bonus: 'Enhancement',
-        modifier: '23%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Doublestrike (ML:34)',
-    description: 'Slotted Effect: +17% Enhancement bonus to Doublestrike.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Doublestrike',
-        bonus: 'Enhancement',
-        modifier: '17%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Doubleshot (ML:34)',
-    description: 'Slotted Effect: +9% Enhancement bonus to Doubleshot.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Doubleshot',
-        bonus: 'Enhancement',
-        modifier: '9%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Strength (ML:34)',
-    description: 'Slotted Effect: +3 Quality bonus to Strength.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Strength',
-        bonus: 'Quality',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Dexterity (ML:34)',
-    description: 'Slotted Effect: +3 Quality bonus to Dexterity.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Dexterity',
-        bonus: 'Quality',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Constitution (ML:34)',
-    description: 'Slotted Effect: +3 Quality bonus to Constitution.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Constitution',
-        bonus: 'Quality',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Intelligence (ML:34)',
-    description: 'Slotted Effect: +3 Quality bonus to Intelligence.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Intelligence',
-        bonus: 'Quality',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Wisdom (ML:34)',
-    description: 'Slotted Effect: +3 Quality bonus to Wisdom.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Wisdom',
-        bonus: 'Quality',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Charisma (ML:34)',
-    description: 'Slotted Effect: +3 Quality bonus to Charisma.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Charisma',
-        bonus: 'Quality',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Accuracy (ML:34)',
-    description: 'Slotted Effect: +5 Quality bonus to Attack.',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Attack',
-        bonus: 'Quality',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Damage (ML:34)',
-    description: 'Slotted Effect: ',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Damage',
-        bonus: 'Quality',
-        modifier: 5,
-        notes: ''
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Quality Combat Mastery (ML:34)',
-    description: 'Slotted Effect: ',
-    minimumLevel: 34,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Trip DC',
-        bonus: 'Quality',
-        modifier: 3
-      },
-      {
-        name: 'Improved Trip DC',
-        bonus: 'Quality',
-        modifier: 3
-      },
-      {
-        name: 'Sunder DC',
-        bonus: 'Quality',
-        modifier: 3
-      },
-      {
-        name: 'Improved Sunder DC',
-        bonus: 'Quality',
-        modifier: 3
-      },
-      {
-        name: 'Stunning Blow DC',
-        bonus: 'Quality',
-        modifier: 3
-      },
-      {
-        name: 'Stunning Fist DC',
-        bonus: 'Quality',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
   // Heroic Augments
   {
     name: 'Melancholic Flames (ML:8)',
@@ -5558,6 +6000,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5578,19 +6021,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -5604,6 +6047,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5624,19 +6068,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -5650,6 +6094,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5670,19 +6115,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -5696,6 +6141,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5719,19 +6165,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -5746,6 +6192,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5769,19 +6216,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -5796,6 +6243,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5819,19 +6267,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -5846,6 +6294,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Weapon)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5869,19 +6318,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -5890,12 +6339,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Flames (ML:8)',
+    name: 'Dolorous Flames (ML:8)',
     description:
       'Slotted Effect: Adds Flaming. This effect causes the edges of this weapon to burn with enchanted flames, dealing 6d6 Fire damage on each critical hit.',
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5911,19 +6361,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -5932,12 +6382,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Chill (ML:8)',
+    name: 'Dolorous Chill (ML:8)',
     description:
       'Slotted Effect: Adds Freezing. This effect causes the edges of this weapon to become frozen to the touch, dealing 6d6 Ice damage on each critical hit.',
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5953,19 +6404,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -5974,12 +6425,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Sparks (ML:8)',
+    name: 'Dolorous Sparks (ML:8)',
     description:
       'Slotted Effect: Adds Jolting. This effect causes the edges of this weapon to arc with electricity, dealing 6d6 Lightning damage on each critical hit.',
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -5995,19 +6447,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -6016,12 +6468,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Acid (ML:8)',
+    name: 'Dolorous Acid (ML:8)',
     description:
       'Slotted Effect: Adds Corroding. This effect causes the edges of this weapon to drip with acid, dealing 6d6 Acid damage on each critical hit.',
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6037,19 +6490,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -6058,12 +6511,13 @@ export const update75Augments: AugmentItem[] = [
     weight: 0.01
   },
   {
-    name: 'Dreadful Arcana (ML:8)',
+    name: 'Dolorous Focus (ML:8)',
     description:
       'Slotted Effect: +2 Equipment bonus to all Spell DCs. If this is slotted into a Quarterstaff, also grants a +2% Exceptional bonus to Spell Spell Critical Chance and makes the Quarterstaff an Implement.',
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6087,19 +6541,459 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Fire (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Fire Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fire Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Cold (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Cold Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Cold Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Electric (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Electric Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Electric Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Acid (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Acid Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Acid Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Light (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Light and Alignment Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Light and Alignment Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Negative (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Negative and Poison Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Negative and Poison Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Sonic (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Sonic Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sonic Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Force (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Force and Physical Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Force and Physical Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Positive (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Positive Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Positive Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Arcana: Repair (ML:8)',
+    description: 'Slotted Effect: +35 Insight bonus to Repair Spell Power.',
+    minimumLevel: 34,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Repair Spell Power',
+        bonus: 'Insight',
+        modifier: 35
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
       }
     ],
     baseValue: {
@@ -6113,6 +7007,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6130,23 +7025,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -6160,6 +7055,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6177,23 +7073,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -6207,6 +7103,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6224,23 +7121,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -6254,6 +7151,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6271,23 +7169,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -6301,6 +7199,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6318,23 +7217,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -6348,6 +7247,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -6365,3442 +7265,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Fire (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Fire Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Fire Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Cold (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Cold Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Cold Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Electric (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Electric Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Electric Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Acid (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Acid Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Acid Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Light (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Light and Alignment Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Light and Alignment Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Negative (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Negative and Poison Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Negative and Poison Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Sonic (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Sonic Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Sonic Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Force (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Force and Physical Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Force and Physical Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Positive (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Positive Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Positive Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable Arcana: Repair (ML:8)',
-    description: 'Slotted Effect: +70 Equipment bonus to Repair Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Weapon)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Repair Spell Power',
-        bonus: 'Equipment',
-        modifier: 70
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Strength (ML:8)',
-    description: 'Slotted Effect: +5 Enhancement bonus to Strength.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Strength',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Dexterity (ML:8)',
-    description: 'Slotted Effect: +5 Enhancement bonus to Dexterity.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Dexterity',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Constitution (ML:8)',
-    description: 'Slotted Effect: +5 Enhancement bonus to Constitution.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Constitution',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Intelligence (ML:8)',
-    description: 'Slotted Effect: +5 Enhancement bonus to Intelligence.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Intelligence',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Wisdom (ML:8)',
-    description: 'Slotted Effect: +5 Enhancement bonus to Wisdom.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Wisdom',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Charisma (ML:8)',
-    description: 'Slotted Effect: +5 Enhancement bonus to Charisma.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Charisma',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: False Life (ML:8)',
-    description: 'Slotted Effect: +18 Enhancement bonus to Maximum HP.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Maximum Hit Points',
-        bonus: 'Enhancement',
-        modifier: 18
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Fire Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Fire Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Fire Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Cold Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Cold Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Cold Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Electric Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Electric Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Electric Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Acid Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Acid Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Acid Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Light Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Light and Alignment Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Light and Alignment Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Negative Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Negative and Poison Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Negative and Poison Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Sonic Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Sonic Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Sonic Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Force Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Force and Physical Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Force and Physical Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Positive Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Positive Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Positive Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic: Repair Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +10% Enhancement bonus to Repair Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Repair Spell Crit Damage',
-        bonus: 'Enhancement',
-        modifier: '10%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Healing Amplification (ML:8)',
-    description: 'Slotted Effect: +19 Competence bonus to Positive Healing Amplification.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Positive Healing Amplification',
-        bonus: 'Competence',
-        modifier: 19
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Repair Amplification (ML:8)',
-    description: 'Slotted Effect: +19 Enhancement bonus to Repair Amplification.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Repair Amplification',
-        bonus: 'Enhancement',
-        modifier: 19
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Negative Amplification (ML:8)',
-    description: 'Slotted Effect: +19 Profane bonus to Negative Healing Amplification.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Negative Healing Amplification',
-        bonus: 'Profane',
-        modifier: 19
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Accuracy (ML:8)',
-    description: 'Slotted Effect: +8 Competence bonus to Attack.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Attack',
-        bonus: 'Competence',
-        modifier: 8
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Damage (ML:8)',
-    description: 'Slotted Effect: +4 Competence bonus to Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Damage',
-        bonus: 'Competence',
-        modifier: 4
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Deception (ML:8)',
-    description: 'Slotted Effect: +3 Enhancement bonus to Sneak Attacks, +5 Enhancement bonus to Sneak Attack Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Sneak Attack',
-        bonus: 'Enhancement',
-        modifier: 3
-      },
-      {
-        name: 'Sneak Attack Damage',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Seeker (ML:8)',
-    description: 'Slotted Effect: +5 Enhancement bonus to Critical Confirmation and Critical Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Critical Confirmation',
-        bonus: 'Enhancement',
-        modifier: 5
-      },
-      {
-        name: 'Critical Damage',
-        bonus: 'Enhancement',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Fire Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Fire Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Fire Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Cold Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Cold Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Cold Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Electric Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Electric Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Electric Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Acid Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Acid Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Acid Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Light Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Light and Alignment Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Light and Alignment Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Negative Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Negative and Poison Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Negative and Poison Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Sonic Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Sonic Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Sonic Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Force Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Force and Physical Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Force and Physical Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Positive Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Positive Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Positive Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous: Repair Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +5% Insight bonus to Repair Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Repair Spell Crit Damage',
-        bonus: 'Insight',
-        modifier: '5%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Physical Resistance Rating (ML:8)',
-    description: 'Slotted Effect: +12 Enhancement bonus to Physical Resistance Rating.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Physical Resistance Rating',
-        bonus: 'Enhancement',
-        modifier: 12
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Magical Resistance Rating (ML:8)',
-    description: 'Slotted Effect: +12 Enhancement bonus to Magical Resistance Rating.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Magical Resistance Rating',
-        bonus: 'Enhancement',
-        modifier: 12
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Spell Penetration (ML:8)',
-    description: 'Slotted Effect: +3 Equipment bonus to Spell Penetration.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Spell Penetration',
-        bonus: 'Equipment',
-        modifier: 3
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Stunning (ML:8)',
-    description: 'Slotted Effect: +6 Enhancement bonus to Stunning DCs.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Stunning DC',
-        bonus: 'Enhancement',
-        modifier: 6
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Trip (ML:8)',
-    description: 'Slotted Effect: +6 Enhancement bonus to Trip DCs.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Trip DC',
-        bonus: 'Enhancement',
-        modifier: 6
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Sunder (ML:8)',
-    description: 'Slotted Effect: +6 Enhancement bonus to Sunder DCs.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Sunder DC',
-        bonus: 'Enhancement',
-        modifier: 6
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Assassinate (ML:8)',
-    description: 'Slotted Effect: +6 Enhancement bonus to Assassinate DCs.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Assassinate DC',
-        bonus: 'Enhancement',
-        modifier: 6
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Fire Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Fire Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Fire Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Cold Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Cold Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Cold Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Electric Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Electric Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Electric Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Acid Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Acid Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Acid Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Light Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Light and Alignment Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Light and Alignment Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Negative Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Negative and Poison Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Negative and Poison Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Sonic Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Sonic Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Sonic Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Force Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Force and Physical Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Force and Physical Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Positive Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Positive Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Positive Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Miserable: Repair Spell Crit Damage (ML:8)',
-    description: 'Slotted Effect: +2% Quality bonus to Repair Spell Crit Damage.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Miserable (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Repair Spell Crit Damage',
-        bonus: 'Quality',
-        modifier: '2%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Woeful: Resistance (ML:8)',
-    description: 'Slotted Effect: +4 Resistance bonus to all Saving Throws.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Woeful (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Saving Throws (all)',
-        bonus: 'Resistance',
-        modifier: 4
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Woeful: Enhanced Ghostly (ML:8)',
-    description:
-      'Slotted Effect: Enhanced Ghostly. Equipping this item causes you to become partially incorporeal. Your melee and missile attacks do not miss a chance for Incorporeal targets. Enemy attacks has a 15% chance to miss you due to your incorporeality. You receive a +5 Enhancement bonus to your Hide and Move Silently skills.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Woeful (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Enhanced Ghostly'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Woeful: Relentless Fury (ML:8)',
-    description:
-      'Slotted Effect: Relentless Fury. While this item is equipped, any killing blows you strike against enemies may drive you into a furious rage, providing a 5% Enhancement damage bonus to your melee, ranged, and unarmed attacks for 30 seconds. Slaying weaker opponents has a reduced chance of producing this effect.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Woeful (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Relentless Fury'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Woeful: Armor Piercing (ML:8)',
-    description: 'Slotted Effect: +8% Enhancement bonus to Fortification Bypass.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Woeful (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Fortification Bypass',
-        bonus: 'Enhancement',
-        modifier: '8%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Woeful: Wizardry (ML:8)',
-    description: 'Slotted Effect: +96 Enhancement bonus to Maximum SP.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Woeful (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Maximum Spell Points',
-        bonus: 'Enhancement',
-        modifier: 96
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Woeful: Profane DCs (ML:8)',
-    description: 'Slotted Effect: You have a +1 Profane bonus to Spell DCs.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Woeful (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Spell DCs',
-        bonus: 'Profane',
-        modifier: 1
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Woeful: Sacred DCs (ML:8)',
-    description: 'Slotted Effect: You have a +1 Sacred bonus to Spell DCs.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Woeful (Accessory)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Spell DCs',
-        bonus: 'Sacred',
-        modifier: 1
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic Plating (ML:8)',
-    description: 'Slotted Effect: +70% Enhancement bonus to Fortification.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Armor)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Fortification',
-        bonus: 'Enhancement',
-        modifier: '70%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic Converter (ML:8)',
-    description:
-      'Slotted Effect: +19 Competence bonus to Healing Amplification, +19 Enhancement bonus to Repair Amplification, and +19 Profane bonus to Negative Amplification.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Armor)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Healing Amplification',
-        bonus: 'Competence',
-        modifier: 19
-      },
-      {
-        name: 'Repair Amplification',
-        bonus: 'Enhancement',
-        modifier: 19
-      },
-      {
-        name: 'Negative Amplification',
-        bonus: 'Profane',
-        modifier: 19
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic Device (ML:8)',
-    description: 'Slotted Effect: You have Deathblock and are Ghostly.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Armor)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Deathblock'
-      },
-      {
-        name: 'Ghostly'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Melancholic Booster (ML:8)',
-    description: 'Slotted Effect: +3% Exceptional bonus to Universal Spell Lore.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Melancholic (Armor)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Universal Spell Lore',
-        bonus: 'Exceptional',
-        modifier: '3%'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Wire',
-        quantity: 100
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 25
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 25
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous Silencer (ML:8)',
-    description: 'Slotted Effect: +1d6 Profane bonus to your Sneak Attack Dice.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Armor)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Sneak Attack Dice',
-        bonus: 'Profane',
-        modifier: '1d6'
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous Invigorator (ML:8)',
-    description: 'Slotted Effect: +1 Profane bonus to Spell DCs, Tactical DCs, and Assassinate.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Armor)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Spell DCs',
-        bonus: 'Profane',
-        modifier: 1
-      },
-      {
-        name: 'Tactical DCs',
-        bonus: 'Profane',
-        modifier: 1
-      },
-      {
-        name: 'Assassinate',
-        bonus: 'Profane',
-        modifier: 1
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
-      }
-    ],
-    baseValue: {
-      platinum: 500
-    },
-    weight: 0.01
-  },
-  {
-    name: 'Dolorous Voidwheel (ML:8)',
-    description: 'Slotted Effect: +5 Exceptional bonus to Universal Spell Power.',
-    minimumLevel: 8,
-    type: 'Augment',
-    augmentType: 'Lamordia: Dolorous (Armor)',
-    binding: {
-      type: 'Bound',
-      to: 'Account',
-      from: 'Acquisition'
-    },
-    update: 75,
-    craftedIn: 'Ludendorf Town Hall',
-    effectsAdded: [
-      {
-        name: 'Universal Spell Power',
-        bonus: 'Exceptional',
-        modifier: 5
-      }
-    ],
-    requirements: [
-      {
-        name: 'Bleak Transformer',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Alternator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Resistor',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Insulator',
-        quantity: 50
-      },
-      {
-        name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 5
       }
     ],
     baseValue: {
@@ -9815,6 +7296,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -9826,23 +7308,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -9857,6 +7339,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -9866,29 +7349,29 @@ export const update75Augments: AugmentItem[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: 'Maiming'
+        name: 'Maiming 2'
       }
     ],
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -9903,6 +7386,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -9920,23 +7404,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -9951,6 +7435,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -9968,23 +7453,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -9999,6 +7484,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10016,23 +7502,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -10047,6 +7533,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'miserableAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10064,23 +7551,23 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -10111,23 +7598,1251 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Wire',
-        quantity: 100
+        quantity: 20
       },
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Fire (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Fire Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fire Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Cold (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Cold Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Cold Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Electric (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Electric Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Electric Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Acid (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Acid Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Acid Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Light (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Light and Alignment Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Light and Alignment Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Negative (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Negative and Poison Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Negative and Poison Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Sonic (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Sonic Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sonic Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Force (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Force and Physical Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Force and Physical Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Positive (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Positive Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Positive Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable Arcana: Repair (ML:8)',
+    description: 'Slotted Effect: +70 Equipment bonus to Repair Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Weapon)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Repair Spell Power',
+        bonus: 'Equipment',
+        modifier: 70
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Strength (ML:8)',
+    description: 'Slotted Effect: +5 Enhancement bonus to Strength.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Strength',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Dexterity (ML:8)',
+    description: 'Slotted Effect: +5 Enhancement bonus to Dexterity.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Dexterity',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Constitution (ML:8)',
+    description: 'Slotted Effect: +5 Enhancement bonus to Constitution.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Constitution',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Intelligence (ML:8)',
+    description: 'Slotted Effect: +5 Enhancement bonus to Intelligence.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Intelligence',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Wisdom (ML:8)',
+    description: 'Slotted Effect: +5 Enhancement bonus to Wisdom.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Wisdom',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Charisma (ML:8)',
+    description: 'Slotted Effect: +5 Enhancement bonus to Charisma.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Charisma',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: False Life (ML:8)',
+    description: 'Slotted Effect: +18 Enhancement bonus to Maximum HP.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Maximum Hit Points',
+        bonus: 'Enhancement',
+        modifier: 18
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Fire Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Fire Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fire Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Cold Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Cold Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Cold Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Electric Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Electric Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Electric Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Acid Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Acid Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Acid Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Light Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Light and Alignment Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Light and Alignment Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Negative Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Negative and Poison Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Negative and Poison Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Sonic Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Sonic Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sonic Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Force Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Force and Physical Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Force and Physical Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Positive Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Positive Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Positive Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic: Repair Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +10% Enhancement bonus to Repair Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Repair Spell Crit Damage',
+        bonus: 'Enhancement',
+        modifier: '10%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
       }
     ],
     baseValue: {
@@ -10141,6 +8856,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10158,19 +8874,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     baseValue: {
@@ -10184,6 +8900,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Melancholic (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10201,19 +8918,777 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Healing Amplification (ML:8)',
+    description: 'Slotted Effect: +19 Competence bonus to Positive Healing Amplification.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Positive Healing Amplification',
+        bonus: 'Competence',
+        modifier: 19
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Repair Amplification (ML:8)',
+    description: 'Slotted Effect: +19 Enhancement bonus to Repair Amplification.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Repair Amplification',
+        bonus: 'Enhancement',
+        modifier: 19
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Negative Amplification (ML:8)',
+    description: 'Slotted Effect: +19 Profane bonus to Negative Healing Amplification.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Negative Healing Amplification',
+        bonus: 'Profane',
+        modifier: 19
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Accuracy (ML:8)',
+    description: 'Slotted Effect: +8 Competence bonus to Attack.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Attack',
+        bonus: 'Competence',
+        modifier: 8
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Damage (ML:8)',
+    description: 'Slotted Effect: +4 Competence bonus to Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Damage',
+        bonus: 'Competence',
+        modifier: 4
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Deception (ML:8)',
+    description: 'Slotted Effect: +3 Enhancement bonus to Sneak Attacks, +5 Enhancement bonus to Sneak Attack Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sneak Attack',
+        bonus: 'Enhancement',
+        modifier: 3
+      },
+      {
+        name: 'Sneak Attack Damage',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Seeker (ML:8)',
+    description: 'Slotted Effect: +5 Enhancement bonus to Critical Confirmation and Critical Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Critical Confirmation',
+        bonus: 'Enhancement',
+        modifier: 5
+      },
+      {
+        name: 'Critical Damage',
+        bonus: 'Enhancement',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Fire Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Fire Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fire Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Cold Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Cold Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Cold Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Electric Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Electric Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Electric Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Acid Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Acid Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Acid Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Light Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Light and Alignment Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Light and Alignment Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Negative Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Negative and Poison Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Negative and Poison Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Sonic Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Sonic Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sonic Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Force Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Force and Physical Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Force and Physical Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Positive Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Positive Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Positive Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous: Repair Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +5% Insight bonus to Repair Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Repair Spell Crit Damage',
+        bonus: 'Insight',
+        modifier: '5%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10227,6 +9702,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10244,19 +9720,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10270,6 +9746,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10287,19 +9764,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10313,6 +9790,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10330,19 +9808,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10356,6 +9834,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10373,19 +9852,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10399,6 +9878,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10416,19 +9896,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10442,6 +9922,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10459,19 +9940,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10485,6 +9966,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10502,19 +9984,19 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10528,6 +10010,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10539,27 +10022,25 @@ export const update75Augments: AugmentItem[] = [
       {
         name: 'Damage',
         bonus: 'Quality',
-        modifier: 1,
-        notes:
-          'As of Loot Preview #2, the in-game interface on Lamannia says this provides Wisdom which is likely incorrect.'
+        modifier: 1
       }
     ],
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
       }
     ],
     baseValue: {
@@ -10574,6 +10055,7 @@ export const update75Augments: AugmentItem[] = [
     minimumLevel: 8,
     type: 'Augment',
     augmentType: 'Lamordia: Dolorous (Accessory)',
+    image: 'melancholicAugment',
     binding: {
       type: 'Bound',
       to: 'Account',
@@ -10616,19 +10098,1527 @@ export const update75Augments: AugmentItem[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Resistor',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Insulator',
-        quantity: 50
+        quantity: 10
       },
       {
         name: 'Bleak Conductor',
-        quantity: 50
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Physical Resistance Rating (ML:8)',
+    description: 'Slotted Effect: +12 Enhancement bonus to Physical Resistance Rating.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Physical Resistance Rating',
+        bonus: 'Enhancement',
+        modifier: 12
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Magical Resistance Rating (ML:8)',
+    description: 'Slotted Effect: +12 Enhancement bonus to Magical Resistance Rating.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Magical Resistance Rating',
+        bonus: 'Enhancement',
+        modifier: 12
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Spell Penetration (ML:8)',
+    description: 'Slotted Effect: +3 Equipment bonus to Spell Penetration.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Spell Penetration',
+        bonus: 'Equipment',
+        modifier: 3
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Stunning (ML:8)',
+    description: 'Slotted Effect: +6 Enhancement bonus to Stunning DCs.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Stunning DC',
+        bonus: 'Enhancement',
+        modifier: 6
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Trip (ML:8)',
+    description: 'Slotted Effect: +6 Enhancement bonus to Trip DCs.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Trip DC',
+        bonus: 'Enhancement',
+        modifier: 6
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Sunder (ML:8)',
+    description: 'Slotted Effect: +6 Enhancement bonus to Sunder DCs.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sunder DC',
+        bonus: 'Enhancement',
+        modifier: 6
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Assassinate (ML:8)',
+    description: 'Slotted Effect: +6 Enhancement bonus to Assassinate DCs.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Assassinate DC',
+        bonus: 'Enhancement',
+        modifier: 6
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Fire Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Fire Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fire Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Cold Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Cold Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Cold Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Electric Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Electric Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Electric Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Acid Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Acid Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Acid Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Light Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Light and Alignment Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Light and Alignment Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Negative Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Negative and Poison Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Negative and Poison Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Sonic Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Sonic Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sonic Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Force Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Force and Physical Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Force and Physical Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Positive Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Positive Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Positive Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Miserable: Repair Spell Crit Damage (ML:8)',
+    description: 'Slotted Effect: +2% Quality bonus to Repair Spell Crit Damage.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Miserable (Accessory)',
+    image: 'miserableAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Repair Spell Crit Damage',
+        bonus: 'Quality',
+        modifier: '2%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Woeful: Resistance (ML:8)',
+    description: 'Slotted Effect: +4 Resistance bonus to all Saving Throws.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Woeful (Accessory)',
+    image: 'woefulAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Saving Throws (all)',
+        bonus: 'Resistance',
+        modifier: 4
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Woeful: Enhanced Ghostly (ML:8)',
+    description:
+      'Slotted Effect: Enhanced Ghostly. Equipping this item causes you to become partially incorporeal. Your melee and missile attacks do not miss a chance for Incorporeal targets. Enemy attacks has a 15% chance to miss you due to your incorporeality. You receive a +5 Enhancement bonus to your Hide and Move Silently skills.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Woeful (Accessory)',
+    image: 'woefulAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Enhanced Ghostly'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Woeful: Relentless Fury (ML:8)',
+    description:
+      'Slotted Effect: Relentless Fury. While this item is equipped, any killing blows you strike against enemies may drive you into a furious rage, providing a 5% Enhancement damage bonus to your melee, ranged, and unarmed attacks for 30 seconds. Slaying weaker opponents has a reduced chance of producing this effect.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Woeful (Accessory)',
+    image: 'woefulAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Relentless Fury'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Woeful: Armor Piercing (ML:8)',
+    description: 'Slotted Effect: +8% Enhancement bonus to Fortification Bypass.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Woeful (Accessory)',
+    image: 'woefulAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fortification Bypass',
+        bonus: 'Enhancement',
+        modifier: '8%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Woeful: Wizardry (ML:8)',
+    description: 'Slotted Effect: +96 Enhancement bonus to Maximum SP.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Woeful (Accessory)',
+    image: 'woefulAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Maximum Spell Points',
+        bonus: 'Enhancement',
+        modifier: 96
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Woeful: Profane DCs (ML:8)',
+    description: 'Slotted Effect: You have a +1 Profane bonus to Spell DCs.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Woeful (Accessory)',
+    image: 'woefulAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Spell DCs',
+        bonus: 'Profane',
+        modifier: 1
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Woeful: Sacred DCs (ML:8)',
+    description: 'Slotted Effect: You have a +1 Sacred bonus to Spell DCs.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Woeful (Accessory)',
+    image: 'woefulAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Spell DCs',
+        bonus: 'Sacred',
+        modifier: 1
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic Plating (ML:8)',
+    description: 'Slotted Effect: +70% Enhancement bonus to Fortification.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Armor)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Fortification',
+        bonus: 'Enhancement',
+        modifier: '70%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic Converter (ML:8)',
+    description:
+      'Slotted Effect: +19 Competence bonus to Healing Amplification, +19 Enhancement bonus to Repair Amplification, and +19 Profane bonus to Negative Amplification.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Armor)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Healing Amplification',
+        bonus: 'Competence',
+        modifier: 19
+      },
+      {
+        name: 'Repair Amplification',
+        bonus: 'Enhancement',
+        modifier: 19
+      },
+      {
+        name: 'Negative Amplification',
+        bonus: 'Profane',
+        modifier: 19
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic Device (ML:8)',
+    description: 'Slotted Effect: You have Deathblock and are Ghostly.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Armor)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Deathblock'
+      },
+      {
+        name: 'Ghostly'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Melancholic Booster (ML:8)',
+    description: 'Slotted Effect: +3% Exceptional bonus to Universal Spell Lore.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Melancholic (Armor)',
+    image: 'melancholicAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Universal Spell Lore',
+        bonus: 'Exceptional',
+        modifier: '3%'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Wire',
+        quantity: 20
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 5
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 5
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Silencer (ML:8)',
+    description: 'Slotted Effect: +1d6 Profane bonus to your Sneak Attack Dice.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Armor)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Sneak Attack Dice',
+        bonus: 'Profane',
+        modifier: '1d6'
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Invigorator (ML:8)',
+    description: 'Slotted Effect: +1 Profane bonus to Spell DCs, Tactical DCs, and Assassinate.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Armor)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Spell DCs',
+        bonus: 'Profane',
+        modifier: 1
+      },
+      {
+        name: 'Tactical DCs',
+        bonus: 'Profane',
+        modifier: 1
+      },
+      {
+        name: 'Assassinate',
+        bonus: 'Profane',
+        modifier: 1
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
+      }
+    ],
+    baseValue: {
+      platinum: 500
+    },
+    weight: 0.01
+  },
+  {
+    name: 'Dolorous Voidwheel (ML:8)',
+    description: 'Slotted Effect: +5 Exceptional bonus to Universal Spell Power.',
+    minimumLevel: 8,
+    type: 'Augment',
+    augmentType: 'Lamordia: Dolorous (Armor)',
+    image: 'dolorousAugment',
+    binding: {
+      type: 'Bound',
+      to: 'Account',
+      from: 'Acquisition'
+    },
+    update: 75,
+    craftedIn: 'Ludendorf Town Hall',
+    effectsAdded: [
+      {
+        name: 'Universal Spell Power',
+        bonus: 'Exceptional',
+        modifier: 5
+      }
+    ],
+    requirements: [
+      {
+        name: 'Bleak Transformer',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Alternator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Resistor',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Insulator',
+        quantity: 10
+      },
+      {
+        name: 'Bleak Conductor',
+        quantity: 10
       }
     ],
     baseValue: {

--- a/src/data/ingredients.ts
+++ b/src/data/ingredients.ts
@@ -344,6 +344,7 @@ export const ingredients: Ingredient[] = [
   },
   {
     name: 'Bleak Transformer',
+    image: 'bleakTransformer',
     description: 'This small piece of machinery can be used to create dreadful machinery in Lamordia.',
     binding: {
       type: 'Unbound'

--- a/src/data/viktraniumExperiment/hViktraniumExperimentCraftedItems.ts
+++ b/src/data/viktraniumExperiment/hViktraniumExperimentCraftedItems.ts
@@ -14,7 +14,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -26,19 +31,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -63,7 +68,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -75,19 +85,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -112,7 +122,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -124,19 +139,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -161,7 +176,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -173,19 +193,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -210,7 +230,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -222,19 +247,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -259,7 +284,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -271,19 +301,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -308,7 +338,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -320,19 +355,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -357,7 +392,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -369,19 +409,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -406,7 +446,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -418,19 +463,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -455,7 +500,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -467,19 +517,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -504,7 +554,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -516,19 +571,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -553,7 +608,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -565,19 +625,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -602,7 +662,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -614,19 +679,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -651,7 +716,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -663,19 +733,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -700,7 +770,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -712,19 +787,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -749,7 +824,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -761,19 +841,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -798,7 +878,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -810,19 +895,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -847,7 +932,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -859,19 +949,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -896,7 +986,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -908,19 +1003,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -945,7 +1040,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -957,19 +1057,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -994,7 +1094,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1006,19 +1111,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1043,7 +1148,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1055,19 +1165,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1092,7 +1202,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1104,19 +1219,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1141,7 +1256,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1153,19 +1273,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1190,7 +1310,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1202,19 +1327,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1239,7 +1364,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1251,19 +1381,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1288,7 +1418,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1300,19 +1435,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1337,7 +1472,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1353,19 +1493,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1390,7 +1530,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1406,19 +1551,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1443,7 +1588,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1459,19 +1609,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1496,7 +1646,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1512,19 +1667,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1549,7 +1704,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1565,19 +1725,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1602,7 +1762,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1614,19 +1779,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1651,7 +1816,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1663,19 +1833,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1700,7 +1870,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1712,19 +1887,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1749,7 +1924,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1761,19 +1941,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1798,7 +1978,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1810,19 +1995,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1847,7 +2032,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1859,19 +2049,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1896,7 +2086,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1908,19 +2103,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1945,7 +2140,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -1957,19 +2157,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [
@@ -1994,7 +2194,12 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     craftedIn: 'Ludendorf Town Hall',
     effectsAdded: [
       {
-        name: '+4 Enhancement Bonus',
+        name: 'Attack',
+        bonus: 'Enhancement',
+        modifier: 4
+      },
+      {
+        name: 'Damage',
         bonus: 'Enhancement',
         modifier: 4
       },
@@ -2008,19 +2213,19 @@ const HViktraniumExperimentCraftedItems: CraftingIngredient[] = [
     requirements: [
       {
         name: 'Bleak Alternator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Resistor',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Insulator',
-        quantity: 25
+        quantity: 5
       },
       {
         name: 'Bleak Conductor',
-        quantity: 25
+        quantity: 5
       }
     ],
     augments: [

--- a/src/pages/dinosaurBoneCrafting/components/CumulativeIngredientsCard.tsx
+++ b/src/pages/dinosaurBoneCrafting/components/CumulativeIngredientsCard.tsx
@@ -1,4 +1,10 @@
-import { Card, ListGroup, Stack } from 'react-bootstrap'
+import camelcase from 'camelcase'
+import { Card, Container, ListGroup, Stack } from 'react-bootstrap'
+import FallbackImage from '../../../components/common/FallbackImage.tsx'
+import { ingredients as ings } from '../../../data/ingredients.ts'
+import type { Ingredient } from '../../../types/ingredients.ts'
+import { ICON_BASE } from '../../../utils/constants.ts'
+import { formatIngredientName } from '../../../utils/utils.ts'
 
 const CumulativeIngredientsCard = (props: Props) => {
   const { ingredients } = props
@@ -10,19 +16,32 @@ const CumulativeIngredientsCard = (props: Props) => {
       <Card.Header>
         <Card.Title className='m-0'>All Ingredients</Card.Title>
       </Card.Header>
+
       <Card.Body className='p-0'>
         {sortedEntries.length === 0 ? (
           <div className='text-muted text-center'>No ingredients to display</div>
         ) : (
           <ListGroup variant='flush'>
-            {sortedEntries.map(([name, qty]) => (
-              <ListGroup.Item key={name} className='p-2'>
-                <Stack direction='horizontal' className='w-100 justify-content-between align-items-center'>
-                  <span>{name}</span>
-                  <span className='text-muted'>{qty}</span>
-                </Stack>
-              </ListGroup.Item>
-            ))}
+            {sortedEntries.map(([name, qty]) => {
+              const ingredient = ings.find((ingredient: Ingredient) => ingredient.name === name)
+              const formattedName: string = formatIngredientName(ingredient?.image ?? ingredient?.name ?? '')
+              const imageSrc = `${ICON_BASE}${camelcase(formattedName)}.png`
+
+              return (
+                <ListGroup.Item key={name} className='p-2'>
+                  <Stack direction='horizontal' className='w-100 justify-content-between align-items-center'>
+                    <Container className='m-0 p-0 text-start'>
+                      <FallbackImage src={imageSrc} alt={name} width='26px' />
+                      &nbsp;
+                      <span>{name}</span>
+                    </Container>
+                    <Container className='m-0 p-0 text-end'>
+                      <span className='text-muted'>{qty}</span>
+                    </Container>
+                  </Stack>
+                </ListGroup.Item>
+              )
+            })}
           </ListGroup>
         )}
       </Card.Body>

--- a/src/pages/dinosaurBoneCrafting/components/ItemDisplay.tsx
+++ b/src/pages/dinosaurBoneCrafting/components/ItemDisplay.tsx
@@ -1,7 +1,13 @@
+import camelcase from 'camelcase'
 import { Card, ListGroup, Stack } from 'react-bootstrap'
+import FallbackImage from '../../../components/common/FallbackImage.tsx'
 import NoteTooltip from '../../../components/common/NoteTooltip.tsx'
+import { ingredients } from '../../../data/ingredients.ts'
 import type { Enhancement } from '../../../types/core.ts'
 import type { CraftingIngredient } from '../../../types/crafting.ts'
+import type { Ingredient } from '../../../types/ingredients.ts'
+import { ICON_BASE } from '../../../utils/constants.ts'
+import { formatIngredientName } from '../../../utils/utils.ts'
 
 const ItemDisplay = (props: Props) => {
   const { selectedItem } = props
@@ -17,25 +23,35 @@ const ItemDisplay = (props: Props) => {
             <Card className='w-100'>
               <Card.Header>
                 <Card.Title className='m-0' as='h6'>
-                  Crafted In / Location:&nbsp;
+                  Crafted In / Location:
                 </Card.Title>
                 <Card.Subtitle>{selectedItem.craftedIn ?? 'Unknown'}</Card.Subtitle>
               </Card.Header>
 
               <Card.Body className='p-0'>
                 <ListGroup variant='flush'>
-                  {selectedItem.requirements.map((req: CraftingIngredient, idx: number) => (
-                    <ListGroup.Item key={`${req.name}-${String(idx)}`}>
-                      <Stack direction='horizontal' className='w-100 align-items-center justify-content-between'>
-                        <strong>
-                          <small>{req.name}</small>
-                        </strong>
-                        <span className='text-muted'>
-                          <small>{req.quantity ?? 1}</small>
-                        </span>
-                      </Stack>
-                    </ListGroup.Item>
-                  ))}
+                  {selectedItem.requirements.map((req: CraftingIngredient, idx: number) => {
+                    const ingredient: Ingredient | undefined = ingredients.find(
+                      (ingredient: Ingredient) => ingredient.name === req.name
+                    )
+                    const formattedName: string = formatIngredientName(ingredient?.image ?? ingredient?.name ?? '')
+                    const imageSrc = `${ICON_BASE}${camelcase(formattedName)}.png`
+
+                    return (
+                      <ListGroup.Item key={`${req.name}-${String(idx)}`}>
+                        <Stack direction='horizontal' className='w-100 align-items-center justify-content-between'>
+                          <strong>
+                            <FallbackImage src={imageSrc} alt={req.name} width='26px' />
+                            &nbsp;
+                            <small>{req.name}</small>
+                          </strong>
+                          <span className='text-muted'>
+                            <small>{req.quantity ?? 1}</small>
+                          </span>
+                        </Stack>
+                      </ListGroup.Item>
+                    )
+                  })}
                 </ListGroup>
               </Card.Body>
             </Card>

--- a/src/pages/puzzles/Shroud.tsx
+++ b/src/pages/puzzles/Shroud.tsx
@@ -200,7 +200,7 @@ const Shroud = () => {
               }
 
               const baseClasses = 'd-flex align-items-center justify-content-center bg-body'
-              // green border for un‐clicked solution tiles, yellow for clicked ones
+              // green border for un‐clicked solution tiles
               const borderClasses: string = press ? toggleMarked(marked) : 'border'
 
               const style: React.CSSProperties = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,26 +33,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/core@npm:7.28.0"
+"@babel/core@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/core@npm:7.28.3"
   dependencies:
     "@ampproject/remapping": "npm:^2.2.0"
     "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.0"
+    "@babel/generator": "npm:^7.28.3"
     "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-module-transforms": "npm:^7.27.3"
-    "@babel/helpers": "npm:^7.27.6"
-    "@babel/parser": "npm:^7.28.0"
+    "@babel/helper-module-transforms": "npm:^7.28.3"
+    "@babel/helpers": "npm:^7.28.3"
+    "@babel/parser": "npm:^7.28.3"
     "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.28.0"
-    "@babel/types": "npm:^7.28.0"
+    "@babel/traverse": "npm:^7.28.3"
+    "@babel/types": "npm:^7.28.2"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 10c0/423302e7c721e73b1c096217880272e02020dfb697a55ccca60ad01bba90037015f84d0c20c6ce297cf33a19bb704bc5c2b3d3095f5284dfa592bd1de0b9e8c3
+  checksum: 10c0/e6b3eb830c4b93f5a442b305776df1cd2bb4fafa4612355366f67c764f3e54a69d45b84def77fb2d4fd83439102667b0a92c3ea2838f678733245b748c602a7b
   languageName: node
   linkType: hard
 
@@ -69,16 +69,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/generator@npm:7.28.0"
+"@babel/generator@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/generator@npm:7.28.3"
   dependencies:
-    "@babel/parser": "npm:^7.28.0"
-    "@babel/types": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.28.3"
+    "@babel/types": "npm:^7.28.2"
     "@jridgewell/gen-mapping": "npm:^0.3.12"
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
-  checksum: 10c0/1b3d122268ea3df50fde707ad864d9a55c72621357d5cebb972db3dd76859c45810c56e16ad23123f18f80cc2692f5a015d2858361300f0f224a05dc43d36a92
+  checksum: 10c0/0ff58bcf04f8803dcc29479b547b43b9b0b828ec1ee0668e92d79f9e90f388c28589056637c5ff2fd7bcf8d153c990d29c448d449d852bf9d1bc64753ca462bc
   languageName: node
   linkType: hard
 
@@ -112,16 +112,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.27.3":
-  version: 7.27.3
-  resolution: "@babel/helper-module-transforms@npm:7.27.3"
+"@babel/helper-module-transforms@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/helper-module-transforms@npm:7.28.3"
   dependencies:
     "@babel/helper-module-imports": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.27.3"
+    "@babel/traverse": "npm:^7.28.3"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/fccb4f512a13b4c069af51e1b56b20f54024bcf1591e31e978a30f3502567f34f90a80da6a19a6148c249216292a8074a0121f9e52602510ef0f32dbce95ca01
+  checksum: 10c0/549be62515a6d50cd4cfefcab1b005c47f89bd9135a22d602ee6a5e3a01f27571868ada10b75b033569f24dc4a2bb8d04bfa05ee75c16da7ade2d0db1437fcdb
   languageName: node
   linkType: hard
 
@@ -153,13 +153,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.27.6":
-  version: 7.28.2
-  resolution: "@babel/helpers@npm:7.28.2"
+"@babel/helpers@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/helpers@npm:7.28.3"
   dependencies:
     "@babel/template": "npm:^7.27.2"
     "@babel/types": "npm:^7.28.2"
-  checksum: 10c0/f3e7b21517e2699c4ca193663ecfb1bf1b2ae2762d8ba4a9f1786feaca0d6984537fc60bf2206e92c43640a6dada6b438f523cc1ad78610d0151aeb061b37f63
+  checksum: 10c0/03a8f94135415eec62d37be9c62c63908f2d5386c7b00e04545de4961996465775330e3eb57717ea7451e19b0e24615777ebfec408c2adb1df3b10b4df6bf1ce
   languageName: node
   linkType: hard
 
@@ -174,14 +174,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/parser@npm:7.28.0"
+"@babel/parser@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/parser@npm:7.28.3"
   dependencies:
-    "@babel/types": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.2"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10c0/c2ef81d598990fa949d1d388429df327420357cb5200271d0d0a2784f1e6d54afc8301eb8bdf96d8f6c77781e402da93c7dc07980fcc136ac5b9d5f1fce701b5
+  checksum: 10c0/1f41eb82623b0ca0f94521b57f4790c6c457cd922b8e2597985b36bdec24114a9ccf54640286a760ceb60f11fe9102d192bf60477aee77f5d45f1029b9b72729
   languageName: node
   linkType: hard
 
@@ -225,7 +225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3":
+"@babel/traverse@npm:^7.27.1":
   version: 7.27.4
   resolution: "@babel/traverse@npm:7.27.4"
   dependencies:
@@ -240,18 +240,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/traverse@npm:7.28.0"
+"@babel/traverse@npm:^7.28.3":
+  version: 7.28.3
+  resolution: "@babel/traverse@npm:7.28.3"
   dependencies:
     "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.0"
+    "@babel/generator": "npm:^7.28.3"
     "@babel/helper-globals": "npm:^7.28.0"
-    "@babel/parser": "npm:^7.28.0"
+    "@babel/parser": "npm:^7.28.3"
     "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.28.0"
+    "@babel/types": "npm:^7.28.2"
     debug: "npm:^4.3.1"
-  checksum: 10c0/32794402457827ac558173bcebdcc0e3a18fa339b7c41ca35621f9f645f044534d91bb923ff385f5f960f2e495f56ce18d6c7b0d064d2f0ccb55b285fa6bc7b9
+  checksum: 10c0/26e95b29a46925b7b41255e03185b7e65b2c4987e14bbee7bbf95867fb19c69181f301bbe1c7b201d4fe0cce6aa0cbea0282dad74b3a0fef3d9058f6c76fdcb3
   languageName: node
   linkType: hard
 
@@ -265,7 +265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.28.0, @babel/types@npm:^7.28.2":
+"@babel/types@npm:^7.28.2":
   version: 7.28.2
   resolution: "@babel/types@npm:7.28.2"
   dependencies:
@@ -959,10 +959,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-beta.30":
-  version: 1.0.0-beta.30
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.30"
-  checksum: 10c0/aff8b532cb9d82d94c9a4101fa12ecb10620ad47d52dbb9135a5c65bde1ad19895b41026b821f4d607083699239a5d0010198401b6a6a54ab6a10d0015302768
+"@rolldown/pluginutils@npm:1.0.0-beta.32":
+  version: 1.0.0-beta.32
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.32"
+  checksum: 10c0/ba3582fc3c35c8eb57b0df2d22d0733b1be83d37edcc258203364773f094f58fc0cb7a056d604603573a69dd0105a466506cad467f59074e1e53d0dc26191f06
   languageName: node
   linkType: hard
 
@@ -1216,12 +1216,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^24.2.1":
-  version: 24.2.1
-  resolution: "@types/node@npm:24.2.1"
+"@types/node@npm:^24.3.0":
+  version: 24.3.0
+  resolution: "@types/node@npm:24.3.0"
   dependencies:
     undici-types: "npm:~7.10.0"
-  checksum: 10c0/439a3c7edf88a298e0c92e46f670234070b892589c3b06e82cc86c47a7e1cf220f4a4b4736ec6ac7e4b9e1c40d7b6d443a1e22f99dd17f13f9dd15de3b32011b
+  checksum: 10c0/96bdeca01f690338957c2dcc92cb9f76c262c10398f8d91860865464412b0f9d309c24d9b03d0bdd26dd47fa7ee3f8227893d5c89bc2009d919a525a22512030
   languageName: node
   linkType: hard
 
@@ -1291,106 +1291,106 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.39.1"
+"@typescript-eslint/eslint-plugin@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.40.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.39.1"
-    "@typescript-eslint/type-utils": "npm:8.39.1"
-    "@typescript-eslint/utils": "npm:8.39.1"
-    "@typescript-eslint/visitor-keys": "npm:8.39.1"
+    "@typescript-eslint/scope-manager": "npm:8.40.0"
+    "@typescript-eslint/type-utils": "npm:8.40.0"
+    "@typescript-eslint/utils": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.39.1
+    "@typescript-eslint/parser": ^8.40.0
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/7a55de558ed6ea6f09ee0b0d994b4a70e1df9f72e4afc7b3073de1b41504a36d905779304d59c34db700af60da3bb438c62480d30462a13b8b72d0b50318aeee
+  checksum: 10c0/dc8889c3255bce6956432f099059179dd13826ba29670f81ba9238ecde46764ee63459eb73a7d88f4f30e1144a2f000d79c9e3f256fa759689d9b3b74d423bda
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/parser@npm:8.39.1"
+"@typescript-eslint/parser@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/parser@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.39.1"
-    "@typescript-eslint/types": "npm:8.39.1"
-    "@typescript-eslint/typescript-estree": "npm:8.39.1"
-    "@typescript-eslint/visitor-keys": "npm:8.39.1"
+    "@typescript-eslint/scope-manager": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/typescript-estree": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/da30372c4e8dee48a0c421996bf0bf73a62a57039ee6b817eda64de2d70fdb88dd20b50615c81be7e68fd29cdd7852829b859bb8539b4a4c78030f93acaf5664
+  checksum: 10c0/43ca9589b8a1f3f4b30a214c0e2254fa0ad43458ef1258b1d62c5aad52710ad11b9315b124cda79163274147b82201a5d76fab7de413e34bfe8e377142b71e98
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/project-service@npm:8.39.1"
+"@typescript-eslint/project-service@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/project-service@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.39.1"
-    "@typescript-eslint/types": "npm:^8.39.1"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.40.0"
+    "@typescript-eslint/types": "npm:^8.40.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/40207af4f4e2a260ea276766d502c4736f6dc5488e84bbab6444e2786289ece2dbca2686323c48d4e9c265e409a309bf3d97d4aa03767dff8cc7642b436bda35
+  checksum: 10c0/23d62e9ada9750136d0251f268bbe1f9784442ef258bb340a2e1e866749d8076730a14749d9a320d94d7c76df2d108caf21fe35e5dc100385f04be846dc979cb
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.39.1"
+"@typescript-eslint/scope-manager@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.39.1"
-    "@typescript-eslint/visitor-keys": "npm:8.39.1"
-  checksum: 10c0/9466db557c1a0eaaf24b0ece5810413d11390d046bf6e47c4074879e8dba0348b835a21106c842ab20ff85f2384312cf9e20bfe7684e31640696e29957003511
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
+  checksum: 10c0/48af81f9cdcec466994d290561e8d2fa3f6b156a898b71dd0e65633c896543b44729c5353596e84de2ae61bfd20e1398c3309cdfe86714a9663fd5aded4c9cd0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.39.1, @typescript-eslint/tsconfig-utils@npm:^8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.39.1"
+"@typescript-eslint/tsconfig-utils@npm:8.40.0, @typescript-eslint/tsconfig-utils@npm:^8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.40.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/664dff0b4ae908cb98c78f9ca73c36cf57c3a2206965d9d0659649ffc02347eb30e1452499671a425592f14a2a5c5eb82ae389b34f3c415a12119506b4ebb61c
+  checksum: 10c0/c2366dcd802901d5cd4f59fc4eab7a00ed119aa4591ba59c507fe495d9af4cfca19431a603602ea675e4c861962230d1c2f100896903750cd1fcfc134702a7d0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/type-utils@npm:8.39.1"
+"@typescript-eslint/type-utils@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/type-utils@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.39.1"
-    "@typescript-eslint/typescript-estree": "npm:8.39.1"
-    "@typescript-eslint/utils": "npm:8.39.1"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/typescript-estree": "npm:8.40.0"
+    "@typescript-eslint/utils": "npm:8.40.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/430dfefe040eae5f0c8dfbce37b5ce071095a28f335e74793923d113682e26313586e90f7bbe2c2f9bffb0da52ffdf5055ea36b96d9f218cef35aa14853122d5
+  checksum: 10c0/660b77d801b2538a4ccb65065269ad0e8370d0be985172b5ecb067f3eea22e64aa8af9e981b31bf2a34002339fe3253b09b55d181ce6d8242fc7daa80ac4aaca
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.39.1, @typescript-eslint/types@npm:^8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/types@npm:8.39.1"
-  checksum: 10c0/0e188d2d52509a24c500a87adf561387ffcac56b62cb9fd0ca1f929bb3d4eedb6b8f9d516c1890855d39930c9dd8d502d5b4600b8c9cc832d3ebb595d81c7533
+"@typescript-eslint/types@npm:8.40.0, @typescript-eslint/types@npm:^8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/types@npm:8.40.0"
+  checksum: 10c0/225374fff36d59288a5780667a7a1316c75090d5d60b70a8035ac18786120333ccd08dfdf0e05e30d5a82217e44c57b8708b769dd1eed89f12f2ac4d3a769f76
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.39.1"
+"@typescript-eslint/typescript-estree@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.39.1"
-    "@typescript-eslint/tsconfig-utils": "npm:8.39.1"
-    "@typescript-eslint/types": "npm:8.39.1"
-    "@typescript-eslint/visitor-keys": "npm:8.39.1"
+    "@typescript-eslint/project-service": "npm:8.40.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -1399,48 +1399,48 @@ __metadata:
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/1de1a37fed354600a08bc971492c2f14238f0a4bf07a43bedb416c17b7312d18bec92c68c8f2790bb0a1bffcd757f7962914be9f6213068f18f6c4fdde259af4
+  checksum: 10c0/6c1ffc17947cb36cbd987cf9705f85223ed1cce584b5244840e36a2b8480861f4dfdb0312f96afbc12e7d1ba586005f0d959042baa0a96a1913ac7ace8e8f6d4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/utils@npm:8.39.1"
+"@typescript-eslint/utils@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/utils@npm:8.40.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.39.1"
-    "@typescript-eslint/types": "npm:8.39.1"
-    "@typescript-eslint/typescript-estree": "npm:8.39.1"
+    "@typescript-eslint/scope-manager": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/typescript-estree": "npm:8.40.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/ebc01d736af43728df9a0915058d0c771dec9cc58846ffdcbb986c78e7dabf547ea7daecd75db58b2af88a3c2a43de8a7e5f81feefacfa31be173fc384d25d77
+  checksum: 10c0/6b3858b8725083fe7db7fb9bcbde930e758a6ba8ddedd1ed27d828fc1cbe04f54b774ef9144602f8eeaafeea9b19b4fd4c46fdad52a10ade99e6b282c7d0df92
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.39.1":
-  version: 8.39.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.39.1"
+"@typescript-eslint/visitor-keys@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.39.1"
+    "@typescript-eslint/types": "npm:8.40.0"
     eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10c0/4d81f6826a211bc2752e25cd16d1f415f28ebc92b35142402ec23f3765f2d00963b75ac06266ad9c674ca5b057d07d8c114116e5bf14f5465dde1d1aa60bc72f
+  checksum: 10c0/592f1c8c2d3da43a7f74f8ead14f05fafc2e4609d5df36811cf92ead5dc94f6f669556a494048e4746cb3774c60bc52a8c83d75369d5e196778d935c70e7d3a1
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@vitejs/plugin-react@npm:5.0.0"
+"@vitejs/plugin-react@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@vitejs/plugin-react@npm:5.0.1"
   dependencies:
-    "@babel/core": "npm:^7.28.0"
+    "@babel/core": "npm:^7.28.3"
     "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
     "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
-    "@rolldown/pluginutils": "npm:1.0.0-beta.30"
+    "@rolldown/pluginutils": "npm:1.0.0-beta.32"
     "@types/babel__core": "npm:^7.20.5"
     react-refresh: "npm:^0.17.0"
   peerDependencies:
     vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10c0/e5813839d319ab5dc1b90cab40b6c08388f26e456166ba9df10ffc3c3f4ecc594cec06715b5c93390bba56140ca5f68a18f2233f7d275d77e5bbfeb979e4fd9b
+  checksum: 10c0/2641171beedfc38edc5671abb47706906f9af2a79a6dfff4e946106c9550de4f83ccae41c164f3ee26a3edf07127ecc0e415fe5cddbf7abc71fbb2540016c27d
   languageName: node
   linkType: hard
 
@@ -2529,7 +2529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.4.4, fdir@npm:^6.4.6":
+"fdir@npm:^6.4.4":
   version: 6.4.6
   resolution: "fdir@npm:6.4.6"
   peerDependencies:
@@ -2538,6 +2538,18 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/45b559cff889934ebb8bc498351e5acba40750ada7e7d6bde197768d2fa67c149be8ae7f8ff34d03f4e1eb20f2764116e56440aaa2f6689e9a4aa7ef06acafe9
+  languageName: node
+  linkType: hard
+
+"fdir@npm:^6.5.0":
+  version: 6.5.0
+  resolution: "fdir@npm:6.5.0"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
   languageName: node
   linkType: hard
 
@@ -4026,21 +4038,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.8.0":
-  version: 7.8.0
-  resolution: "react-router-dom@npm:7.8.0"
+"react-router-dom@npm:^7.8.1":
+  version: 7.8.1
+  resolution: "react-router-dom@npm:7.8.1"
   dependencies:
-    react-router: "npm:7.8.0"
+    react-router: "npm:7.8.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: 10c0/a39a65477249f306935d48c010afd3f34009be66993df02dfa8a13cb79e0f3d61940e4ea0b7dadadb64b9b1f303358a830ed62c08d05cb406196aee6d609bdaf
+  checksum: 10c0/7616ae6b6c741446c6168a4ec760c01cbe24e8d14364a605bb002ba3f9bc060c0307ae1fb01cb76552aceb0dd956f023a0fb23b2f40436173e7e587a28301a8f
   languageName: node
   linkType: hard
 
-"react-router@npm:7.8.0":
-  version: 7.8.0
-  resolution: "react-router@npm:7.8.0"
+"react-router@npm:7.8.1":
+  version: 7.8.1
+  resolution: "react-router@npm:7.8.1"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -4050,7 +4062,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/e2d81a1d673ed5d0851810defc19b7db9d8350e31169e1938efe8392b0b995f4faf7b4c9416c257935e2f28c65297a412a053b39e68ac76095130808c5b24db1
+  checksum: 10c0/6d3229080a0f67f4644e0d8ecdb5e2637f640bf9e3a87c3e1e6ca91cce156cf3606d57dac3899869b25156b8343bc274291345914e45bb30ef38556a14e24eac
   languageName: node
   linkType: hard
 
@@ -4841,18 +4853,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.39.1":
-  version: 8.39.1
-  resolution: "typescript-eslint@npm:8.39.1"
+"typescript-eslint@npm:^8.40.0":
+  version: 8.40.0
+  resolution: "typescript-eslint@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.39.1"
-    "@typescript-eslint/parser": "npm:8.39.1"
-    "@typescript-eslint/typescript-estree": "npm:8.39.1"
-    "@typescript-eslint/utils": "npm:8.39.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.40.0"
+    "@typescript-eslint/parser": "npm:8.40.0"
+    "@typescript-eslint/typescript-estree": "npm:8.40.0"
+    "@typescript-eslint/utils": "npm:8.40.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
-  checksum: 10c0/4070729621c20f8a9bad3df13fb8ac175609a57d046c155df785d474c2926d3e506f0bd5e762be7e2aacd03839c9c9a2015ad087086cee5838c486b9bf46b27b
+  checksum: 10c0/b9bf9cbe13a89348ae2a13a7839238b1b058c1e188d9cc1028810c43f1b48cf256f5255ca94c38acf3cd5a405c918ad96d5b7f7a6ad3f82fa7429122a7883a83
   languageName: node
   linkType: hard
 
@@ -5015,12 +5027,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "vite@npm:7.1.2"
+"vite@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "vite@npm:7.1.3"
   dependencies:
     esbuild: "npm:^0.25.0"
-    fdir: "npm:^6.4.6"
+    fdir: "npm:^6.5.0"
     fsevents: "npm:~2.3.3"
     picomatch: "npm:^4.0.3"
     postcss: "npm:^8.5.6"
@@ -5066,7 +5078,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/4ed825b20bc0f49db99cd382de9506b2721ccd47dcebd4a68e0ef65e3cdd2347fded52b306c34178308e0fd7fe78fd5ff517623002cb00710182ad3012c92ced
+  checksum: 10c0/a0aa418beab80673dc9a3e9d1fa49472955d6ef9d41a4c9c6bd402953f411346f612864dae267adfb2bb8ceeb894482369316ffae5816c84fd45990e352b727d
   languageName: node
   linkType: hard
 
@@ -5229,10 +5241,10 @@ __metadata:
     "@reduxjs/toolkit": "npm:^2.8.2"
     "@types/bootstrap": "npm:^5.2.10"
     "@types/luxon": "npm:^3.7.1"
-    "@types/node": "npm:^24.2.1"
+    "@types/node": "npm:^24.3.0"
     "@types/react": "npm:^19.1.10"
     "@types/react-dom": "npm:^19.1.7"
-    "@vitejs/plugin-react": "npm:^5.0.0"
+    "@vitejs/plugin-react": "npm:^5.0.1"
     bootstrap: "npm:^5.3.7"
     camelcase: "npm:^8.0.0"
     eslint: "npm:^9.33.0"
@@ -5250,14 +5262,14 @@ __metadata:
     react-dom: "npm:^19.1.1"
     react-icons: "npm:^5.5.0"
     react-redux: "npm:^9.2.0"
-    react-router-dom: "npm:^7.8.0"
+    react-router-dom: "npm:^7.8.1"
     sass: "npm:^1.90.0"
     simple-xml-to-json: "npm:^1.2.3"
     sitemap: "npm:^8.0.0"
     title-case: "npm:^4.3.2"
     typescript: "npm:^5.9.2"
-    typescript-eslint: "npm:^8.39.1"
-    vite: "npm:^7.1.2"
+    typescript-eslint: "npm:^8.40.0"
+    vite: "npm:^7.1.3"
     vite-plugin-compression: "npm:^0.5.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
- Add `image` property to all augment entries in `update75.ts`.
- Rename "Dreadful" augments to "Dolorous" in `update75.ts`.
- Add "Dolorous Arcana" augments for various spell powers.
- Add "Miserable" augments for Armor Destruction, Maiming, and Bane.
- Include crafting requirements for new augments in `update75.ts`.