### PR TITLE
Export charBuilder and esotericTable objects as named exports

### DIFF
--- a/src/data/charBuilder/darkBargainer.ts
+++ b/src/data/charBuilder/darkBargainer.ts
@@ -1,4 +1,4 @@
-const darkBargainer = {
+export const darkBargainer = {
   level1: {
     featsAvailable: [
       {

--- a/src/data/charBuilder/defensiveFeats.ts
+++ b/src/data/charBuilder/defensiveFeats.ts
@@ -1,4 +1,4 @@
-const defensiveFeats: object[] = [
+export const defensiveFeats: object[] = [
   { name: 'Diehard', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Force of Personality', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Great Fortitude', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },

--- a/src/data/charBuilder/martialFeats.ts
+++ b/src/data/charBuilder/martialFeats.ts
@@ -1,4 +1,4 @@
-const martialFeats: object[] = [
+export const martialFeats: object[] = [
   { name: 'Sap', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Slicing Blow', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Stunning Blow', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true }

--- a/src/data/charBuilder/metamagicFeats.ts
+++ b/src/data/charBuilder/metamagicFeats.ts
@@ -1,4 +1,4 @@
-const metamagicFeats: object[] = [
+export const metamagicFeats: object[] = [
   { name: 'Empower Spell', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Enlarge Spell', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Eschew Materials', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },

--- a/src/data/charBuilder/proficiencyFeats.ts
+++ b/src/data/charBuilder/proficiencyFeats.ts
@@ -1,4 +1,4 @@
-const proficiencyFeats: object[] = [
+export const proficiencyFeats: object[] = [
   {
     name: 'Martial Weapon Proficiency',
     selectable: [],

--- a/src/data/charBuilder/rangedCombatFeats.ts
+++ b/src/data/charBuilder/rangedCombatFeats.ts
@@ -1,4 +1,4 @@
-const rangedCombatFeats: object = [
+export const rangedCombatFeats: object = [
   { name: 'Point Blank Shot', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Rapid Reload', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true }
 ]

--- a/src/data/charBuilder/skillFocusFeats.ts
+++ b/src/data/charBuilder/skillFocusFeats.ts
@@ -1,4 +1,4 @@
-const skillFocusFeats: object[] = [
+export const skillFocusFeats: object[] = [
   { name: 'Acrobatic', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Alertness', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Athletic', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },

--- a/src/data/charBuilder/spellCastingFeats.ts
+++ b/src/data/charBuilder/spellCastingFeats.ts
@@ -1,4 +1,4 @@
-const spellCastingFeats: object[] = [
+export const spellCastingFeats: object[] = [
   { name: 'Augment Summoning', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Combat Casting', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Mental Toughness', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },

--- a/src/data/charBuilder/warlockClassFeats.ts
+++ b/src/data/charBuilder/warlockClassFeats.ts
@@ -1,4 +1,4 @@
-const warlockClassFeats: object[] = [
+export const warlockClassFeats: object[] = [
   { name: 'Pact: Celestial', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Pact: Fey', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },
   { name: 'Pact: Fiend', selectable: [{ 'Dark Bargainer': [1] }], characterCreation: true },

--- a/src/data/esotericTable/craftingRecipes.ts
+++ b/src/data/esotericTable/craftingRecipes.ts
@@ -1,6 +1,6 @@
 import type { CraftingIngredient } from '../../types/crafting.ts'
 
-const craftingRecipes: CraftingIngredient[] = [
+export const craftingRecipes: CraftingIngredient[] = [
   {
     name: 'Warp the Unholy',
     description:


### PR DESCRIPTION
- Update `darkBargainer.ts` to use `export const darkBargainer`.
- Change `defensiveFeats.ts` to export `defensiveFeats` as a named export.
- Update `martialFeats.ts` to use named export for `martialFeats`.
- Change `metamagicFeats.ts` to export `metamagicFeats` as a named export.
- Update `proficiencyFeats.ts` to use named export for `proficiencyFeats`.
- Change `rangedCombatFeats.ts` to export `rangedCombatFeats` as a named export.
- Update `skillFocusFeats.ts` to use named export for `skillFocusFeats`.
- Change `spellCastingFeats.ts` to export `spellCastingFeats` as a named export.
- Update `warlockClassFeats.ts` to use named export for `warlockClassFeats`.
- Modify `craftingRecipes.ts` to export `craftingRecipes` as a named export.