### PR TITLE
Refactor Cannith Crafting binding logic and upgrade Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "eslint-plugin-sonarjs": "^3.0.5",
     "globals": "^16.5.0",
-    "prettier": "^3.6.2",
+    "prettier": "^3.7.1",
     "sass": "^1.94.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,12 +4000,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.6.2":
-  version: 3.6.2
-  resolution: "prettier@npm:3.6.2"
+"prettier@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "prettier@npm:3.7.1"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/488cb2f2b99ec13da1e50074912870217c11edaddedeadc649b1244c749d15ba94e846423d062e2c4c9ae683e2d65f754de28889ba06e697ac4f988d44f45812
+  checksum: 10c0/a6610043ee0a64a3251a948bf82fad3e59d984a8e8dea206400cfa190585417e3343b32c1f6ae7d8f40798a9b4bd91affc08fa7795dd99a9dec5c9bccdf31500
   languageName: node
   linkType: hard
 
@@ -5358,7 +5358,7 @@ __metadata:
     kebab-case: "npm:^2.0.2"
     luxon: "npm:^3.7.2"
     papaparse: "npm:^5.5.3"
-    prettier: "npm:^3.6.2"
+    prettier: "npm:^3.7.1"
     react: "npm:^19.2.0"
     react-bootstrap: "npm:^2.10.10"
     react-dom: "npm:^19.2.0"


### PR DESCRIPTION
- Remove master and override binding selection logic in UI.
- Update materials rendering to display both Bound and Unbound options.
- Refactor shard material combination to unify Bound and Unbound rows.
- Simplify enhancement filtering logic by removing binding dependency.
- Upgrade Prettier version from 3.6.2 to 3.7.1 in `package.json` and `yarn.lock`.