### PR TITLE
Fix null check in AugmentSlotFilterableDropdown

### DIFF
--- a/src/components/common/AugmentSlotFilterableDropdown.tsx
+++ b/src/components/common/AugmentSlotFilterableDropdown.tsx
@@ -103,7 +103,7 @@ const orderGroups = (
   const result: Record<string, Ingredient[]> = {}
   desired.forEach((k) => {
     // Guard against keys that are in the desired order but not present in the actual groups
-    if (groups[k].length) {
+    if (groups[k]?.length) {
       result[k] = groups[k]
     }
   })


### PR DESCRIPTION
- Updated `groups[k].length` to `groups[k]?.length` for safer access in `AugmentSlotFilterableDropdown.tsx`.