### PR TITLE
Add `lz-string` package to dependencies for string compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fast-xml-parser": "^5.3.2",
     "kebab-case": "^2.0.2",
     "luxon": "^3.7.2",
+    "lz-string": "^1.5.0",
     "papaparse": "^5.5.3",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3556,6 +3556,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10c0/36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^14.0.3":
   version: 14.0.3
   resolution: "make-fetch-happen@npm:14.0.3"
@@ -5357,6 +5366,7 @@ __metadata:
     globals: "npm:^16.5.0"
     kebab-case: "npm:^2.0.2"
     luxon: "npm:^3.7.2"
+    lz-string: "npm:^1.5.0"
     papaparse: "npm:^5.5.3"
     prettier: "npm:^3.7.1"
     react: "npm:^19.2.0"


### PR DESCRIPTION
- Updated `yarn.lock` to include `lz-string@^1.5.0` with resolution details.
- Added `lz-string@^1.5.0` to `dependencies` section in `package.json`.