### PR TITLE
Update quest names in Saga Tracker data

### DIFF
--- a/src/pages/sagaTracker/quests.json
+++ b/src/pages/sagaTracker/quests.json
@@ -892,7 +892,7 @@
   },
   {
     "id": "cb7c1c14-96e6-44e0-bf4a-f6c87ce47ff7",
-    "name": "The End of the Road (H)",
+    "name": "End of the Road (H)",
     "sagas": [
       "honor-the-huntsilver-heroic",
       "perils-of-cormyr-heroic"
@@ -900,7 +900,7 @@
   },
   {
     "id": "5d345acb-f55b-4eba-a6c6-3d45e958a6b7",
-    "name": "The End of the Road (E)",
+    "name": "End of the Road (E)",
     "sagas": [
       "honor-the-huntsilver-epic",
       "perils-of-cormyr-epic"


### PR DESCRIPTION
- Renamed "The End of the Road (H)" to "End of the Road (H)" in `quests.json`.
- Renamed "The End of the Road (E)" to "End of the Road (E)" in `quests.json`.