### PR TITLE
Remove redundant `path` property from `Nearly Finished` menu items

### DIFF
--- a/src/components/navbar/heroicMenu.ts
+++ b/src/components/navbar/heroicMenu.ts
@@ -12,7 +12,7 @@ const menuItems: NavDropdownType[] = [
   { label: 'Green Steel', image: '', active: true },
   { label: 'Incredible Potential', image: '', active: true },
   { label: 'Lost Purpose', image: '', active: false },
-  { label: 'Nearly Finished', image: '', active: true, path: '/nearly-finished' },
+  { label: 'Nearly Finished', image: '', active: true },
   { label: 'Reaper Forge', image: '', active: false },
   { label: 'Stone Of Change', image: '', active: false },
   { label: 'Storemreaver Monument', image: '', active: false },

--- a/src/components/navbar/legendaryMenu.ts
+++ b/src/components/navbar/legendaryMenu.ts
@@ -1,7 +1,7 @@
 import type { NavDropdownType, NavMenuDropdown } from './types.ts'
 
 const menuItems: NavDropdownType[] = [
-  { label: 'Nearly Finished', image: '', active: true, path: '/nearly-finished' },
+  { label: 'Nearly Finished', image: '', active: true },
   { label: 'Cauldron Of Cadence', image: '', active: true },
   { label: 'Legendary Crafting', image: '', active: false },
   { label: 'Nebula Fragment Crafting', image: '', active: false },


### PR DESCRIPTION
- Updated `legendaryMenu.ts` to remove `path` from the `Nearly Finished` item.
- Updated `heroicMenu.ts` to remove `path` from the `Nearly Finished` item.