### PR TITLE
Fix typo in preBuild command in `amplify.yml`

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -15,7 +15,7 @@ frontend:
         - go version
 
         # generate runtime json before frontend build
-        - yuarn preBuild
+        - yarn preBuild
 
     build:
       commands:


### PR DESCRIPTION
- **amplify.yml**: Corrected `yuarn` to `yarn` in the preBuild step.