### PR TITLE
Fix typo in `amplify.yml` prebuild command

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -15,7 +15,7 @@ frontend:
         - go version
 
         # generate runtime json before frontend build
-        - yarn preBuild
+        - yarn prebuild
 
     build:
       commands:


### PR DESCRIPTION
- **amplify.yml**: Corrected `preBuild` to `prebuild` in preBuild phase command.