### PR TITLE
Update weapon name formatting with stylized names

### DIFF
--- a/src/data/basics/weapons.ts
+++ b/src/data/basics/weapons.ts
@@ -33,10 +33,15 @@ export const rangedWeapons = new Set([
   'Great Crossbow',
   'Heavy Crossbow',
   'Light Crossbow',
-  'Longbow',
+  'Long Bow',
   'Repeating Light Crossbow',
   'Repeating Heavy Crossbow',
-  'Shortbow'
+  'Short Bow'
 ])
+
+export const weaponStylizedNames: Record<string, string> = {
+  'Long Bow': 'Longbow',
+  'Short Bow': 'Shortbow'
+}
 
 export const throwingWeapons = new Set(['Dart', 'Shuriken', 'Throwing Axe', 'Throwing Hammer', 'Throwing Dagger'])

--- a/src/data/dinosaurBoneCrafting/factories/attunedBoneWeaponFactory.ts
+++ b/src/data/dinosaurBoneCrafting/factories/attunedBoneWeaponFactory.ts
@@ -1,6 +1,6 @@
 import type { Enhancement } from '../../../types/core.ts'
 import type { CraftingIngredient } from '../../../types/crafting.ts'
-import { meleeWeapons, rangedWeapons, throwingWeapons } from '../../basics/weapons.ts'
+import { meleeWeapons, rangedWeapons, throwingWeapons, weaponStylizedNames } from '../../basics/weapons.ts'
 import { findSetBonus } from '../../setBonuses.ts'
 
 export const attunedBoneWeaponFactory = (
@@ -8,7 +8,7 @@ export const attunedBoneWeaponFactory = (
   itemType: string,
   extraEffects?: Enhancement
 ): CraftingIngredient => ({
-  name: `Attuned Bone ${name}`,
+  name: `Attuned Bone ${weaponStylizedNames[name] || name}`,
   description: 'Fashioned of intricately carved bones of long-forgotten Dinosaurs.',
   type: itemType,
   quantity: 1,

--- a/src/data/dinosaurBoneCrafting/factories/weaponBlankFactory.ts
+++ b/src/data/dinosaurBoneCrafting/factories/weaponBlankFactory.ts
@@ -1,17 +1,13 @@
 import type { Enhancement } from '../../../types/core.ts'
 import type { CraftingIngredient } from '../../../types/crafting.ts'
-import {
-  meleeWeapons,
-  rangedWeapons,
-  throwingWeapons
-} from '../../basics/weapons.ts'
+import { meleeWeapons, rangedWeapons, throwingWeapons, weaponStylizedNames } from '../../basics/weapons.ts'
 
 export const baseDinosaurBoneWeapon = (
   name: string,
   itemType: string,
   extraEffects?: Enhancement
 ): CraftingIngredient => ({
-  name: `Dinosaur Bone ${name}`,
+  name: `Dinosaur Bone ${weaponStylizedNames[name] || name}`,
   description: 'Fashioned of intricately carved bones of long-forgotten Dinosaurs.',
   type: itemType,
   quantity: 1,


### PR DESCRIPTION
- **attunedBoneWeaponFactory.ts**: Use `weaponStylizedNames` for item names.
- **weaponBlankFactory.ts**: Add `weaponStylizedNames` for consistent naming.
- **weapons.ts**: Introduce `weaponStylizedNames` mapping for name variants.