### PR TITLE
**Prevent curses on quivers and add tests for curse handling**

### DIFF
--- a/src/pages/gearPlanner/components/CurseSlotItem.tsx
+++ b/src/pages/gearPlanner/components/CurseSlotItem.tsx
@@ -1,10 +1,13 @@
 import { Dropdown } from 'react-bootstrap'
 import { checkPotentialConflict } from '../conflictResolver.ts'
+import { canApplyCurse } from '../helpers.ts'
 import { type Curse, type EntityGearState, type GearItem, GearSlot } from '../types.ts'
 import EnchantmentList from './EnchantmentList.tsx'
 
 const CurseSlotItem = (props: Props) => {
   const { allCurses, entityState, selectedItem, setCurse, slot, slotted } = props
+
+  if (!canApplyCurse(selectedItem)) return null
 
   const {
     equipped: currentEquipped,

--- a/src/pages/gearPlanner/helpers.ts
+++ b/src/pages/gearPlanner/helpers.ts
@@ -166,6 +166,10 @@ export const isMinorArtifact = (item: LootItem) => {
   return (item.artifactType?.trim().length ?? 0) > 0
 }
 
+export const canApplyCurse = (item: GearItem) => {
+  return item.slot !== GearSlot.Quiver
+}
+
 export const getMaxFiligreeSlots = (item: LootItem) => {
   const minLevel = Number.parseInt(String(item.minLevel), 10) || 1
   if (isMinorArtifact(item)) {

--- a/src/pages/gearPlanner/permalink.ts
+++ b/src/pages/gearPlanner/permalink.ts
@@ -1,7 +1,7 @@
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string'
 import traceOfMadnessData from '../../data/traceOfMadness.json'
 import { getSlotOwner } from './conflictResolver.ts'
-import { isEssenceCraftedName, reconstructEssenceCraftedItem } from './helpers.ts'
+import { canApplyCurse, isEssenceCraftedName, reconstructEssenceCraftedItem } from './helpers.ts'
 import { initialPetState } from './initialState.ts'
 import {
   buildPermalinkPayloadV2,
@@ -341,7 +341,7 @@ const decodeItemAugments = (
 }
 
 const decodeItemCurse = (item: GearItem, curseName: string | null, allCurses: Curse[], state: GearSetup | PetState) => {
-  if (curseName && item.slot !== GearSlot.Quiver) {
+  if (curseName && canApplyCurse(item)) {
     const curse = allCurses.find((c) => c.name === curseName)
     if (curse) state.slottedCurses[item.id] = curse
   }

--- a/src/pages/gearPlanner/permalinkV2.test.ts
+++ b/src/pages/gearPlanner/permalinkV2.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createDefaultSetup, initialPetState } from './initialState'
 import { buildPermalinkPayloadV2, decodePermalinkPayloadV2, isPermalinkPayloadV2 } from './permalinkV2'
-import { type GearItem, GearSlot } from './types'
+import { type Curse, type GearItem, GearSlot } from './types'
 
 describe('permalink V2 payload helpers', () => {
   const mockItem = {
@@ -49,5 +49,25 @@ describe('permalink V2 payload helpers', () => {
     expect(decoded.name).toBe('Setup 1')
     expect(decoded.slots[GearSlot.MainHand]?.id).toBe(mockItem.id)
     expect(decoded.slots[GearSlot.MainHand]?.material).toBe(mockItem.material)
+  })
+
+  it('omits quiver curses from the V2 payload and decode path', () => {
+    const quiverItem = {
+      id: 'Quiver|Test Quiver|1|quiver.json',
+      name: 'Test Quiver',
+      slot: GearSlot.Quiver,
+      minLevel: '1'
+    } as unknown as GearItem
+    const curse = { name: 'Curse of Testing', type: 'Minor' } as Curse
+
+    const setup = createDefaultSetup('setup-1', 'Setup 1')
+    setup.slots[GearSlot.Quiver] = quiverItem
+    setup.slottedCurses[quiverItem.id] = curse
+
+    const payload = buildPermalinkPayloadV2(setup)
+    expect(payload.items[0].curseName).toBeNull()
+
+    const decoded = decodePermalinkPayloadV2(payload, [quiverItem], [], [curse])
+    expect(decoded.slottedCurses[quiverItem.id]).toBeUndefined()
   })
 })

--- a/src/pages/gearPlanner/permalinkV2.ts
+++ b/src/pages/gearPlanner/permalinkV2.ts
@@ -1,6 +1,6 @@
 import traceOfMadnessData from '../../data/traceOfMadness.json'
 import { getSlotOwner } from './conflictResolver'
-import { isEssenceCraftedName, reconstructEssenceCraftedItem } from './helpers'
+import { canApplyCurse, isEssenceCraftedName, reconstructEssenceCraftedItem } from './helpers'
 import { initialPetState } from './initialState'
 import { pickPlannerSetupMetadata } from './plannerStateFields'
 import {
@@ -157,7 +157,7 @@ const decodeItemAugments = (
 }
 
 const decodeItemCurse = (item: GearItem, curseName: string | null, allCurses: Curse[], state: GearSetup | PetState) => {
-  if (curseName && item.slot !== GearSlot.Quiver) {
+  if (curseName && canApplyCurse(item)) {
     const curse = allCurses.find((c) => c.name === curseName)
     if (curse) state.slottedCurses[item.id] = curse
   }
@@ -207,7 +207,7 @@ export const buildPermalinkItemPayloadV2 = (
     itemName: item.name,
     itemId: item.id,
     augments,
-    curseName: state.slottedCurses[item.id]?.name ?? null,
+    curseName: canApplyCurse(item) ? (state.slottedCurses[item.id]?.name ?? null) : null,
     essenceCrafting: essenceCrafting.length > 0 ? essenceCrafting : null,
     nearlyFinished: itemUpgrade.slottedNearlyFinished[item.id] ?? null,
     almostThere: itemUpgrade.slottedAlmostThere[item.id] ?? null,

--- a/src/redux/slices/gearPlannerSlice.test.ts
+++ b/src/redux/slices/gearPlannerSlice.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { createDefaultSetup } from '../../pages/gearPlanner/initialState'
-import { type GearAugment, type GearItem, GearSlot } from '../../pages/gearPlanner/types'
+import { type Curse, type GearAugment, type GearItem, GearSlot } from '../../pages/gearPlanner/types'
 import gearPlannerReducer, {
   type GearPlannerState,
   removeSetup,
+  setCurse,
   setItemMaterial,
   setItemUpgrade
 } from './gearPlannerSlice'
@@ -143,5 +144,37 @@ describe('gearPlannerSlice reducers', () => {
     )
 
     expect(nextState.characterSetups[0].slots[GearSlot.MainHand]?.material).toBe('Adamantine')
+  })
+
+  it('does not apply curses to quivers', () => {
+    const item = {
+      id: 'quiver-1',
+      name: 'Test Quiver',
+      slot: GearSlot.Quiver,
+      minLevel: '1',
+      type: 'Quiver'
+    } as unknown as GearItem
+    const curse = { name: 'Curse of Testing', type: 'Minor' } as Curse
+
+    const initialState: GearPlannerState = {
+      characterSetups: [
+        {
+          ...createDefaultSetup('setup3', 'Setup 3'),
+          slots: { [GearSlot.Quiver]: item } as unknown as Record<GearSlot, GearItem | null>
+        }
+      ],
+      activeSetupId: 'setup3'
+    }
+
+    const nextState = gearPlannerReducer(
+      initialState,
+      setCurse({
+        itemId: item.id,
+        curse,
+        slot: GearSlot.Quiver
+      })
+    )
+
+    expect(nextState.characterSetups[0].slottedCurses[item.id]).toBeUndefined()
   })
 })

--- a/src/redux/slices/gearPlannerSlice.ts
+++ b/src/redux/slices/gearPlannerSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
-import { isMinorArtifact } from '../../pages/gearPlanner/helpers'
+import { canApplyCurse, isMinorArtifact } from '../../pages/gearPlanner/helpers'
 import { createDefaultSetup, initialPetState } from '../../pages/gearPlanner/initialState'
 import {
   ARTIFICER_PET_SLOTS,
@@ -299,6 +299,14 @@ const gearPlannerSlice = createSlice({
     ) => {
       const { itemId, curse, slot } = action.payload
       withActiveTarget(state, slot, (target) => {
+        const currentItem = Object.values(target.slots).find((item) => item?.id === itemId)
+        if (currentItem && !canApplyCurse(currentItem)) {
+          /* eslint-disable @typescript-eslint/no-dynamic-delete */
+          delete target.slottedCurses[itemId]
+          /* eslint-enable @typescript-eslint/no-dynamic-delete */
+          return
+        }
+
         target.slottedCurses[itemId] = curse
       })
     },


### PR DESCRIPTION
- **permalink.ts**: Replaced quiver-specific check with `canApplyCurse`.
- **helpers.ts**: Added `canApplyCurse` utility for curse eligibility.
- **gearPlannerSlice.ts**: Modified reducers to exclude curses from quivers.
- **CurseSlotItem.tsx**: Disabled curse slot for quiver items.
- **permalinkV2.test.ts**: Added test for excluding quiver curses in payload.
- **gearPlannerSlice.test.ts**: Added test for curse application on quivers.