### PR TITLE
Add "Collapse All" functionality to gear planner UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         cache-dependency-path: tools/*/go.mod
 
     - name: Install dependencies
-      run: yarn install
+      run: YARN_ENABLE_SCRIPTS=false yarn install
 
     - name: Prebuild
       run: yarn prebuild

--- a/src/pages/gearPlanner/GearPlanner.css
+++ b/src/pages/gearPlanner/GearPlanner.css
@@ -175,6 +175,61 @@
     padding: 0.2rem 0.5rem;
 }
 
+.gear-planner-slot-header-main,
+.gear-planner-slot-header-collapse {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    padding-left: 0.5rem !important;
+    padding-right: 0.5rem !important;
+    min-height: 2.25rem;
+    line-height: 1.2;
+}
+
+.gear-planner-slot-header-main {
+    flex: 1 1 auto;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.gear-planner-slot-header-main-alone {
+    width: 100%;
+}
+
+.gear-planner-slot-header-label {
+    font-size: 0.85rem;
+    line-height: 1.15;
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.25rem;
+}
+
+.gear-planner-slot-header-main .badge {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+    vertical-align: middle;
+}
+
+.gear-planner-slot-header-collapse {
+    min-width: 2.25rem;
+    padding-inline: 0.6rem !important;
+    border-left: 1px solid rgba(0, 0, 0, 0.12) !important;
+}
+
+.gear-planner-slot-header-main:hover,
+.gear-planner-slot-header-main:focus-visible,
+.gear-planner-slot-header-collapse:hover,
+.gear-planner-slot-header-collapse:focus-visible {
+    background-color: rgba(0, 0, 0, 0.06) !important;
+    text-decoration: none !important;
+}
+
+.gear-planner-collapse-all-btn {
+    padding: 0.2rem 0.55rem !important;
+    font-size: 0.75rem !important;
+    line-height: 1.1;
+}
+
 .set-bonus-badge-clickable {
     cursor: pointer;
     transition: filter 0.2s ease-in-out;

--- a/src/pages/gearPlanner/GearPlanner.tsx
+++ b/src/pages/gearPlanner/GearPlanner.tsx
@@ -237,9 +237,7 @@ const GearPlanner = () => {
               getEntityState={gpHook.getEntityState}
               openSetBonusBrowser={gpHook.openSetBonusBrowser}
               allItemCardsCollapsed={gpHook.allItemCardsCollapsed}
-              onToggleCollapseAll={() => {
-                gpHook.setAllItemCardsCollapsed(!gpHook.allItemCardsCollapsed)
-              }}
+              onToggleCollapseAll={gpHook.toggleAllItemCardsCollapsed}
               onSelectSetup={(setupId) => {
                 dispatch(setActiveSetupAction(setupId))
               }}

--- a/src/pages/gearPlanner/GearPlanner.tsx
+++ b/src/pages/gearPlanner/GearPlanner.tsx
@@ -236,6 +236,10 @@ const GearPlanner = () => {
               renderSlot={gpHook.renderSlot}
               getEntityState={gpHook.getEntityState}
               openSetBonusBrowser={gpHook.openSetBonusBrowser}
+              allItemCardsCollapsed={gpHook.allItemCardsCollapsed}
+              onToggleCollapseAll={() => {
+                gpHook.setAllItemCardsCollapsed(!gpHook.allItemCardsCollapsed)
+              }}
               onSelectSetup={(setupId) => {
                 dispatch(setActiveSetupAction(setupId))
               }}

--- a/src/pages/gearPlanner/components/SetupTabs.tsx
+++ b/src/pages/gearPlanner/components/SetupTabs.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react'
 import { Button, Row, Stack, Tab, Tabs } from 'react-bootstrap'
 import { FaChevronDown, FaXmark } from 'react-icons/fa6'
 import type { EssenceEnchantment } from '../dataLoader'
@@ -55,7 +56,7 @@ interface SummaryState {
 
 const SetupSummaryBlocks = ({
   equippedItems,
-  activeSetup,
+  summarySetup,
   allItems,
   allAugments,
   allCurses,
@@ -65,7 +66,7 @@ const SetupSummaryBlocks = ({
   onBonusClick
 }: {
   equippedItems: GearItem[]
-  activeSetup: SummaryState
+  summarySetup: SummaryState
   allItems: GearItem[]
   allAugments: GearAugment[]
   allCurses: import('../types').Curse[]
@@ -77,31 +78,31 @@ const SetupSummaryBlocks = ({
   <>
     <SetBonusesSummary
       equippedItems={equippedItems}
-      slottedAugments={activeSetup.slottedAugments}
-      slottedFiligrees={activeSetup.slottedFiligrees}
-      slottedGemSetBonuses={activeSetup.slottedGemSetBonuses}
-      slottedLostPurpose={activeSetup.slottedLostPurpose}
+      slottedAugments={summarySetup.slottedAugments}
+      slottedFiligrees={summarySetup.slottedFiligrees}
+      slottedGemSetBonuses={summarySetup.slottedGemSetBonuses}
+      slottedLostPurpose={summarySetup.slottedLostPurpose}
       onSetClick={openSetBonusBrowser}
     />
 
     <EnchantmentsSummary
       equippedItems={equippedItems}
-      slottedAugments={activeSetup.slottedAugments}
-      slottedCurses={activeSetup.slottedCurses}
-      slottedFiligrees={activeSetup.slottedFiligrees}
-      slottedGemSetBonuses={activeSetup.slottedGemSetBonuses}
-      slottedEssenceEnchantments={activeSetup.slottedEssenceEnchantments}
-      itemUpgrades={activeSetup.itemUpgrades}
+      slottedAugments={summarySetup.slottedAugments}
+      slottedCurses={summarySetup.slottedCurses}
+      slottedFiligrees={summarySetup.slottedFiligrees}
+      slottedGemSetBonuses={summarySetup.slottedGemSetBonuses}
+      slottedEssenceEnchantments={summarySetup.slottedEssenceEnchantments}
+      itemUpgrades={summarySetup.itemUpgrades}
       essenceEnchantments={essenceEnchantments}
-      slottedNearlyFinished={activeSetup.slottedNearlyFinished}
-      slottedAlmostThere={activeSetup.slottedAlmostThere}
-      slottedFinishingTouch={activeSetup.slottedFinishingTouch}
-      slottedRitualTable={activeSetup.slottedRitualTable}
-      slottedLostPurpose={activeSetup.slottedLostPurpose}
-      slottedTraceOfMadness={activeSetup.slottedTraceOfMadness}
-      slottedFountainOfNecroticMight={activeSetup.slottedFountainOfNecroticMight}
-      slottedStormreaverUpgrade={activeSetup.slottedStormreaverUpgrade}
-      slottedZhentarimAttuned={activeSetup.slottedZhentarimAttuned}
+      slottedNearlyFinished={summarySetup.slottedNearlyFinished}
+      slottedAlmostThere={summarySetup.slottedAlmostThere}
+      slottedFinishingTouch={summarySetup.slottedFinishingTouch}
+      slottedRitualTable={summarySetup.slottedRitualTable}
+      slottedLostPurpose={summarySetup.slottedLostPurpose}
+      slottedTraceOfMadness={summarySetup.slottedTraceOfMadness}
+      slottedFountainOfNecroticMight={summarySetup.slottedFountainOfNecroticMight}
+      slottedStormreaverUpgrade={summarySetup.slottedStormreaverUpgrade}
+      slottedZhentarimAttuned={summarySetup.slottedZhentarimAttuned}
       allItems={allItems}
       allAugments={allAugments}
       allCurses={allCurses}
@@ -111,26 +112,12 @@ const SetupSummaryBlocks = ({
   </>
 )
 
-const PetGearSection = ({
-  title,
-  slots,
-  setup,
-  entityState,
-  renderSlot,
-  openSetBonusBrowser,
-  onBonusClick,
-  essenceEnchantments,
-  allItems,
-  allAugments,
-  allCurses,
-  allFiligrees,
-  borderColorClass,
-  textColorClass
-}: {
-  title: string
+interface GearSectionProps {
+  title: ReactNode
   slots: GearSlot[]
   setup: GearSetup
-  entityState: EntityGearState
+  summaryState: SummaryState
+  equippedItems: GearItem[]
   renderSlot: (slot: GearSlot, setup: GearSetup) => React.ReactNode
   openSetBonusBrowser: (setName: string | null, slot?: GearSlot | null) => void
   onBonusClick: (name: string, bonusType: string) => void
@@ -139,17 +126,59 @@ const PetGearSection = ({
   allAugments: GearAugment[]
   allCurses: import('../types').Curse[]
   allFiligrees: GearItem[]
-  borderColorClass: string
-  textColorClass: string
-}) => (
-  <div className={`mt-4 p-3 border ${borderColorClass} rounded bg-dark-subtle`}>
-    <h5 className={`mb-3 ${textColorClass} border-bottom ${borderColorClass} pb-2`}>{title}</h5>
+  containerClassName: string
+  headerClassName: string
+  titleClassName: string
+  note?: ReactNode
+  allItemCardsCollapsed?: boolean
+  onToggleCollapseAll?: () => void
+}
+
+const GearSection = ({
+  title,
+  slots,
+  setup,
+  summaryState,
+  equippedItems,
+  renderSlot,
+  openSetBonusBrowser,
+  onBonusClick,
+  essenceEnchantments,
+  allItems,
+  allAugments,
+  allCurses,
+  allFiligrees,
+  containerClassName,
+  headerClassName,
+  titleClassName,
+  note,
+  allItemCardsCollapsed,
+  onToggleCollapseAll
+}: GearSectionProps) => (
+  <div className={containerClassName}>
+    <div className={headerClassName}>
+      <h5 className={titleClassName}>{title}</h5>
+
+      {onToggleCollapseAll && (
+        <Button
+          variant='outline-secondary'
+          size='sm'
+          className='gear-planner-collapse-all-btn d-inline-flex align-items-center gap-1 flex-shrink-0'
+          onClick={onToggleCollapseAll}
+        >
+          <FaChevronDown className={allItemCardsCollapsed ? 'rotate-180' : ''} />
+          {allItemCardsCollapsed ? 'Expand All' : 'Collapse All'}
+        </Button>
+      )}
+    </div>
+
+    {note}
 
     <Row>{slots.map((slot) => renderSlot(slot, setup))}</Row>
 
     <SetupSummaryBlocks
-      equippedItems={entityState.equipped}
-      activeSetup={entityState}
+      equippedItems={equippedItems}
+      summarySetup={summaryState}
       allItems={allItems}
       allAugments={allAugments}
       allCurses={allCurses}
@@ -181,6 +210,10 @@ const SetupTabs = ({
   onBonusClick
 }: SetupTabsProps) => {
   const setupCount = setups.length
+  const artificerPetState = getEntityState('artificer_pet')
+  const druidPetState = getEntityState('druid_pet')
+  const showArtificerPet = activeSetup.classes.includes('Artificer')
+  const showDruidPet = activeSetup.classes.includes('Druid')
 
   return (
     <Tabs
@@ -227,76 +260,73 @@ const SetupTabs = ({
         >
           {setup.id === activeSetupId && (
             <div className='mt-3'>
-              <div className='d-flex align-items-center justify-content-between border-bottom pb-2 mb-3 gap-2'>
-                <h5 className='mb-0'>Equipped Items</h5>
-
-                <Button
-                  variant='outline-secondary'
-                  size='sm'
-                  className='gear-planner-collapse-all-btn d-inline-flex align-items-center gap-1 flex-shrink-0'
-                  onClick={onToggleCollapseAll}
-                >
-                  <FaChevronDown className={allItemCardsCollapsed ? 'rotate-180' : ''} />
-                  {allItemCardsCollapsed ? 'Expand All' : 'Collapse All'}
-                </Button>
-              </div>
-
-              <Row>{GEAR_SLOTS.map((slot) => renderSlot(slot, setup))}</Row>
-
-              <SetupSummaryBlocks
+              <GearSection
+                title='Equipped Items'
+                slots={GEAR_SLOTS}
+                setup={activeSetup}
+                summaryState={activeSetup}
                 equippedItems={characterEquipped}
-                activeSetup={activeSetup}
+                renderSlot={renderSlot}
+                openSetBonusBrowser={openSetBonusBrowser}
+                onBonusClick={onBonusClick}
+                essenceEnchantments={essenceEnchantments}
                 allItems={allItems}
                 allAugments={allAugments}
                 allCurses={allCurses}
                 allFiligrees={allFiligrees}
-                essenceEnchantments={essenceEnchantments}
-                openSetBonusBrowser={openSetBonusBrowser}
-                onBonusClick={onBonusClick}
+                containerClassName='mt-3'
+                headerClassName='d-flex align-items-center justify-content-between border-bottom pb-2 mb-3 gap-2'
+                titleClassName='mb-0'
+                allItemCardsCollapsed={allItemCardsCollapsed}
+                onToggleCollapseAll={onToggleCollapseAll}
               />
 
-              {setup.classes.includes('Artificer') && setup.classes.includes('Druid') && (
+              {showArtificerPet && (
+                <GearSection
+                  title='Iron Defender (Artificer Pet)'
+                  slots={ARTIFICER_PET_SLOTS}
+                  setup={activeSetup}
+                  summaryState={artificerPetState}
+                  equippedItems={artificerPetState.equipped}
+                  renderSlot={renderSlot}
+                  openSetBonusBrowser={openSetBonusBrowser}
+                  onBonusClick={onBonusClick}
+                  essenceEnchantments={essenceEnchantments}
+                  allItems={allItems}
+                  allAugments={allAugments}
+                  allCurses={allCurses}
+                  allFiligrees={allFiligrees}
+                  containerClassName='mt-4 p-3 border border-info rounded bg-dark-subtle'
+                  headerClassName='mb-3 text-info border-bottom border-info pb-2'
+                  titleClassName='mb-0'
+                />
+              )}
+
+              {showDruidPet && (
+                <GearSection
+                  title='Wolf Companion (Druid Pet)'
+                  slots={DRUID_PET_SLOTS}
+                  setup={activeSetup}
+                  summaryState={druidPetState}
+                  equippedItems={druidPetState.equipped}
+                  renderSlot={renderSlot}
+                  openSetBonusBrowser={openSetBonusBrowser}
+                  onBonusClick={onBonusClick}
+                  essenceEnchantments={essenceEnchantments}
+                  allItems={allItems}
+                  allAugments={allAugments}
+                  allCurses={allCurses}
+                  allFiligrees={allFiligrees}
+                  containerClassName='mt-4 p-3 border border-success rounded bg-dark-subtle'
+                  headerClassName='mb-3 text-success border-bottom border-success pb-2'
+                  titleClassName='mb-0'
+                />
+              )}
+
+              {showArtificerPet && showDruidPet && (
                 <div className='mt-3 p-2 bg-warning-subtle text-warning-emphasis border border-warning rounded small text-center fw-bold'>
                   Note: Only one pet may be active at a time.
                 </div>
-              )}
-
-              {setup.classes.includes('Artificer') && (
-                <PetGearSection
-                  title='Iron Defender (Artificer Pet)'
-                  slots={ARTIFICER_PET_SLOTS}
-                  setup={setup}
-                  entityState={getEntityState('artificer_pet')}
-                  renderSlot={renderSlot}
-                  openSetBonusBrowser={openSetBonusBrowser}
-                  onBonusClick={onBonusClick}
-                  essenceEnchantments={essenceEnchantments}
-                  allItems={allItems}
-                  allAugments={allAugments}
-                  allCurses={allCurses}
-                  allFiligrees={allFiligrees}
-                  borderColorClass='border-info'
-                  textColorClass='text-info'
-                />
-              )}
-
-              {setup.classes.includes('Druid') && (
-                <PetGearSection
-                  title='Wolf Companion (Druid Pet)'
-                  slots={DRUID_PET_SLOTS}
-                  setup={setup}
-                  entityState={getEntityState('druid_pet')}
-                  renderSlot={renderSlot}
-                  openSetBonusBrowser={openSetBonusBrowser}
-                  onBonusClick={onBonusClick}
-                  essenceEnchantments={essenceEnchantments}
-                  allItems={allItems}
-                  allAugments={allAugments}
-                  allCurses={allCurses}
-                  allFiligrees={allFiligrees}
-                  borderColorClass='border-success'
-                  textColorClass='text-success'
-                />
               )}
             </div>
           )}

--- a/src/pages/gearPlanner/components/SetupTabs.tsx
+++ b/src/pages/gearPlanner/components/SetupTabs.tsx
@@ -35,6 +35,82 @@ interface SetupTabsProps {
   onBonusClick: (name: string, bonusType: string) => void
 }
 
+interface SummaryState {
+  slottedAugments: EntityGearState['slottedAugments']
+  slottedFiligrees: EntityGearState['slottedFiligrees']
+  slottedGemSetBonuses: EntityGearState['slottedGemSetBonuses']
+  slottedLostPurpose: EntityGearState['slottedLostPurpose']
+  slottedCurses: EntityGearState['slottedCurses']
+  slottedEssenceEnchantments: EntityGearState['slottedEssenceEnchantments']
+  itemUpgrades: EntityGearState['itemUpgrades']
+  slottedNearlyFinished: EntityGearState['slottedNearlyFinished']
+  slottedAlmostThere: EntityGearState['slottedAlmostThere']
+  slottedFinishingTouch: EntityGearState['slottedFinishingTouch']
+  slottedRitualTable: EntityGearState['slottedRitualTable']
+  slottedTraceOfMadness: EntityGearState['slottedTraceOfMadness']
+  slottedFountainOfNecroticMight: EntityGearState['slottedFountainOfNecroticMight']
+  slottedStormreaverUpgrade: EntityGearState['slottedStormreaverUpgrade']
+  slottedZhentarimAttuned: EntityGearState['slottedZhentarimAttuned']
+}
+
+const SetupSummaryBlocks = ({
+  equippedItems,
+  activeSetup,
+  allItems,
+  allAugments,
+  allCurses,
+  allFiligrees,
+  essenceEnchantments,
+  openSetBonusBrowser,
+  onBonusClick
+}: {
+  equippedItems: GearItem[]
+  activeSetup: SummaryState
+  allItems: GearItem[]
+  allAugments: GearAugment[]
+  allCurses: import('../types').Curse[]
+  allFiligrees: GearItem[]
+  essenceEnchantments: EssenceEnchantment[]
+  openSetBonusBrowser: (setName: string | null, slot?: GearSlot | null) => void
+  onBonusClick: (name: string, bonusType: string) => void
+}) => (
+  <>
+    <SetBonusesSummary
+      equippedItems={equippedItems}
+      slottedAugments={activeSetup.slottedAugments}
+      slottedFiligrees={activeSetup.slottedFiligrees}
+      slottedGemSetBonuses={activeSetup.slottedGemSetBonuses}
+      slottedLostPurpose={activeSetup.slottedLostPurpose}
+      onSetClick={openSetBonusBrowser}
+    />
+
+    <EnchantmentsSummary
+      equippedItems={equippedItems}
+      slottedAugments={activeSetup.slottedAugments}
+      slottedCurses={activeSetup.slottedCurses}
+      slottedFiligrees={activeSetup.slottedFiligrees}
+      slottedGemSetBonuses={activeSetup.slottedGemSetBonuses}
+      slottedEssenceEnchantments={activeSetup.slottedEssenceEnchantments}
+      itemUpgrades={activeSetup.itemUpgrades}
+      essenceEnchantments={essenceEnchantments}
+      slottedNearlyFinished={activeSetup.slottedNearlyFinished}
+      slottedAlmostThere={activeSetup.slottedAlmostThere}
+      slottedFinishingTouch={activeSetup.slottedFinishingTouch}
+      slottedRitualTable={activeSetup.slottedRitualTable}
+      slottedLostPurpose={activeSetup.slottedLostPurpose}
+      slottedTraceOfMadness={activeSetup.slottedTraceOfMadness}
+      slottedFountainOfNecroticMight={activeSetup.slottedFountainOfNecroticMight}
+      slottedStormreaverUpgrade={activeSetup.slottedStormreaverUpgrade}
+      slottedZhentarimAttuned={activeSetup.slottedZhentarimAttuned}
+      allItems={allItems}
+      allAugments={allAugments}
+      allCurses={allCurses}
+      allFiligrees={allFiligrees}
+      onBonusClick={onBonusClick}
+    />
+  </>
+)
+
 const PetGearSection = ({
   title,
   slots,
@@ -71,37 +147,15 @@ const PetGearSection = ({
 
     <Row>{slots.map((slot) => renderSlot(slot, setup))}</Row>
 
-    <SetBonusesSummary
+    <SetupSummaryBlocks
       equippedItems={entityState.equipped}
-      slottedAugments={entityState.slottedAugments}
-      slottedFiligrees={entityState.slottedFiligrees}
-      slottedGemSetBonuses={entityState.slottedGemSetBonuses}
-      slottedLostPurpose={entityState.slottedLostPurpose}
-      onSetClick={openSetBonusBrowser}
-    />
-
-    <EnchantmentsSummary
-      equippedItems={entityState.equipped}
-      slottedAugments={entityState.slottedAugments}
-      slottedCurses={entityState.slottedCurses}
-      slottedFiligrees={entityState.slottedFiligrees}
-      slottedGemSetBonuses={entityState.slottedGemSetBonuses}
-      slottedEssenceEnchantments={entityState.slottedEssenceEnchantments}
-      itemUpgrades={entityState.itemUpgrades}
-      essenceEnchantments={essenceEnchantments}
-      slottedNearlyFinished={entityState.slottedNearlyFinished}
-      slottedAlmostThere={entityState.slottedAlmostThere}
-      slottedFinishingTouch={entityState.slottedFinishingTouch}
-      slottedRitualTable={entityState.slottedRitualTable}
-      slottedLostPurpose={entityState.slottedLostPurpose}
-      slottedTraceOfMadness={entityState.slottedTraceOfMadness}
-      slottedFountainOfNecroticMight={entityState.slottedFountainOfNecroticMight}
-      slottedStormreaverUpgrade={entityState.slottedStormreaverUpgrade}
-      slottedZhentarimAttuned={entityState.slottedZhentarimAttuned}
+      activeSetup={entityState}
       allItems={allItems}
       allAugments={allAugments}
       allCurses={allCurses}
       allFiligrees={allFiligrees}
+      essenceEnchantments={essenceEnchantments}
+      openSetBonusBrowser={openSetBonusBrowser}
       onBonusClick={onBonusClick}
     />
   </div>
@@ -189,37 +243,15 @@ const SetupTabs = ({
 
               <Row>{GEAR_SLOTS.map((slot) => renderSlot(slot, setup))}</Row>
 
-              <SetBonusesSummary
+              <SetupSummaryBlocks
                 equippedItems={characterEquipped}
-                slottedAugments={activeSetup.slottedAugments}
-                slottedFiligrees={activeSetup.slottedFiligrees}
-                slottedGemSetBonuses={activeSetup.slottedGemSetBonuses}
-                slottedLostPurpose={activeSetup.slottedLostPurpose}
-                onSetClick={openSetBonusBrowser}
-              />
-
-              <EnchantmentsSummary
-                equippedItems={characterEquipped}
-                slottedAugments={activeSetup.slottedAugments}
-                slottedCurses={activeSetup.slottedCurses}
-                slottedFiligrees={activeSetup.slottedFiligrees}
-                slottedGemSetBonuses={activeSetup.slottedGemSetBonuses}
-                slottedEssenceEnchantments={activeSetup.slottedEssenceEnchantments}
-                itemUpgrades={activeSetup.itemUpgrades}
-                essenceEnchantments={essenceEnchantments}
-                slottedNearlyFinished={activeSetup.slottedNearlyFinished}
-                slottedAlmostThere={activeSetup.slottedAlmostThere}
-                slottedFinishingTouch={activeSetup.slottedFinishingTouch}
-                slottedRitualTable={activeSetup.slottedRitualTable}
-                slottedLostPurpose={activeSetup.slottedLostPurpose}
-                slottedTraceOfMadness={activeSetup.slottedTraceOfMadness}
-                slottedFountainOfNecroticMight={activeSetup.slottedFountainOfNecroticMight}
-                slottedStormreaverUpgrade={activeSetup.slottedStormreaverUpgrade}
-                slottedZhentarimAttuned={activeSetup.slottedZhentarimAttuned}
+                activeSetup={activeSetup}
                 allItems={allItems}
                 allAugments={allAugments}
                 allCurses={allCurses}
                 allFiligrees={allFiligrees}
+                essenceEnchantments={essenceEnchantments}
+                openSetBonusBrowser={openSetBonusBrowser}
                 onBonusClick={onBonusClick}
               />
 

--- a/src/pages/gearPlanner/components/SetupTabs.tsx
+++ b/src/pages/gearPlanner/components/SetupTabs.tsx
@@ -1,5 +1,5 @@
 import { Button, Row, Stack, Tab, Tabs } from 'react-bootstrap'
-import { FaXmark } from 'react-icons/fa6'
+import { FaChevronDown, FaXmark } from 'react-icons/fa6'
 import type { EssenceEnchantment } from '../dataLoader'
 import {
   ARTIFICER_PET_SLOTS,
@@ -28,6 +28,8 @@ interface SetupTabsProps {
   renderSlot: (slot: GearSlot, setup: GearSetup) => React.ReactNode
   getEntityState: (owner: 'artificer_pet' | 'druid_pet') => EntityGearState
   openSetBonusBrowser: (setName: string | null, slot?: GearSlot | null) => void
+  allItemCardsCollapsed: boolean
+  onToggleCollapseAll: () => void
   onSelectSetup: (setupId: string) => void
   onDeleteSetup: (setupId: string) => void
   onBonusClick: (name: string, bonusType: string) => void
@@ -118,6 +120,8 @@ const SetupTabs = ({
   renderSlot,
   getEntityState,
   openSetBonusBrowser,
+  allItemCardsCollapsed,
+  onToggleCollapseAll,
   onSelectSetup,
   onDeleteSetup,
   onBonusClick
@@ -169,7 +173,19 @@ const SetupTabs = ({
         >
           {setup.id === activeSetupId && (
             <div className='mt-3'>
-              <h5 className='mb-3 border-bottom pb-2'>Equipped Items</h5>
+              <div className='d-flex align-items-center justify-content-between border-bottom pb-2 mb-3 gap-2'>
+                <h5 className='mb-0'>Equipped Items</h5>
+
+                <Button
+                  variant='outline-secondary'
+                  size='sm'
+                  className='gear-planner-collapse-all-btn d-inline-flex align-items-center gap-1 flex-shrink-0'
+                  onClick={onToggleCollapseAll}
+                >
+                  <FaChevronDown className={allItemCardsCollapsed ? 'rotate-180' : ''} />
+                  {allItemCardsCollapsed ? 'Expand All' : 'Collapse All'}
+                </Button>
+              </div>
 
               <Row>{GEAR_SLOTS.map((slot) => renderSlot(slot, setup))}</Row>
 

--- a/src/pages/gearPlanner/components/gearPlannerParts.test.tsx
+++ b/src/pages/gearPlanner/components/gearPlannerParts.test.tsx
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { Provider } from 'react-redux'
 import type { Location } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import gearPlannerReducer, { type GearPlannerState } from '../../../redux/slices/gearPlannerSlice'
+import { renderGearPlanner } from '../hooks/renderGearPlanner'
 import { createDefaultSetup } from '../initialState'
 import { GearSlot } from '../types'
 import { createUpgradeViews } from '../upgradeState'
@@ -90,6 +92,7 @@ describe('Gear planner extracted UI parts', () => {
     const renderSlot = vi.fn((slot: GearSlot) => <div key={slot} data-testid={`slot-${slot}`} />)
     const onSelectSetup = vi.fn()
     const onDeleteSetup = vi.fn()
+    const onToggleCollapseAll = vi.fn()
 
     render(
       <SetupTabs
@@ -124,6 +127,8 @@ describe('Gear planner extracted UI parts', () => {
           }) as never
         }
         openSetBonusBrowser={vi.fn()}
+        allItemCardsCollapsed={false}
+        onToggleCollapseAll={onToggleCollapseAll}
         onSelectSetup={onSelectSetup}
         onDeleteSetup={onDeleteSetup}
         onBonusClick={vi.fn()}
@@ -131,6 +136,7 @@ describe('Gear planner extracted UI parts', () => {
     )
 
     expect(screen.getAllByText('Equipped Items')[0]).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /collapse all/i })).toBeInTheDocument()
     expect(screen.getAllByTestId(`slot-${GearSlot.Eyes}`)[0]).toBeInTheDocument()
     expect(screen.getAllByTestId('set-bonuses-summary')[0]).toBeInTheDocument()
     expect(screen.getAllByTestId('enchantments-summary')[0]).toBeInTheDocument()
@@ -144,6 +150,106 @@ describe('Gear planner extracted UI parts', () => {
     const secondTab = screen.getByRole('tab', { name: 'Setup 2' })
     await user.click(within(secondTab).getByRole('button'))
     expect(onDeleteSetup).toHaveBeenCalledWith('setup-2')
+
+    await user.click(screen.getByRole('button', { name: /collapse all/i }))
+    expect(onToggleCollapseAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses and expands an item card from the card action', async () => {
+    const user = userEvent.setup()
+    const store = configureStore({
+      reducer: {
+        app: () => ({ troveData: null })
+      }
+    })
+
+    const activeSetup = createDefaultSetup('setup-1', 'Setup 1')
+    const selectedItem = {
+      id: 'item-1',
+      name: 'Test Item',
+      minimumLevel: 20,
+      minLevel: 20,
+      type: 'Weapon',
+      material: 'Wood',
+      augments: [],
+      enchantments: [],
+      setBonus: [],
+      essenceSlots: []
+    }
+    const entityState = {
+      slots: {
+        [GearSlot.Head]: selectedItem
+      },
+      equipped: [],
+      conflicts: {},
+      slottedAugments: {},
+      slottedNearlyFinished: {},
+      slottedAlmostThere: {},
+      slottedFinishingTouch: {},
+      slottedRitualTable: {},
+      slottedLostPurpose: {},
+      slottedTraceOfMadness: {},
+      slottedFountainOfNecroticMight: {},
+      slottedStormreaverUpgrade: {},
+      slottedZhentarimAttuned: {},
+      slottedReaperForge: {}
+    } as never
+
+    const Harness = () => {
+      const [collapsedItemCards, setCollapsedItemCards] = useState<Record<string, boolean>>({})
+      const { renderSlot } = renderGearPlanner({
+        activeSetup,
+        getEntityState: () => entityState,
+        troveData: null,
+        allAugments: [],
+        allCurses: [],
+        openSlotBrowser: vi.fn(),
+        openSetBonusBrowser: vi.fn(),
+        formatDropLocations: () => null,
+        isMetal: () => false,
+        setItemMinLevel: vi.fn(),
+        setItemMaterial: vi.fn(),
+        essenceEnchantments: [],
+        setSlottedGemSetBonus: vi.fn(),
+        setSlottedAugment: vi.fn(),
+        setSlottedCurse: vi.fn(),
+        setEssenceEnchantment: vi.fn(),
+        setNearlyFinishedEnchantment: vi.fn(),
+        setAlmostThereEnchantment: vi.fn(),
+        setFinishingTouchEnchantment: vi.fn(),
+        setRitualTableEnchantment: vi.fn(),
+        setLostPurposeEnchantment: vi.fn(),
+        setTraceOfMadnessEnchantment: vi.fn(),
+        setFountainOfNecroticMight: vi.fn(),
+        setStormreaverUpgrade: vi.fn(),
+        setZhentarimAttuned: vi.fn(),
+        setReaperForge: vi.fn(),
+        isItemCardCollapsed: (itemId: string) => collapsedItemCards[itemId] ?? false,
+        toggleItemCardCollapsed: (itemId: string) => {
+          setCollapsedItemCards((prev) => ({
+            ...prev,
+            [itemId]: !prev[itemId]
+          }))
+        },
+        allItemCardsCollapsed: false,
+        setAllItemCardsCollapsed: vi.fn()
+      })
+
+      return <Provider store={store}>{renderSlot(GearSlot.Head, activeSetup)}</Provider>
+    }
+
+    render(<Harness />)
+
+    expect(screen.getByText(/ML: 20 \| Weapon/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /collapse test item/i }))
+
+    expect(screen.getByText(/ML: 20 \| Weapon/i)).toBeInTheDocument()
+    expect(screen.getByText('Test Item')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /expand test item/i }))
+
+    expect(screen.getByText(/ML: 20 \| Weapon/i)).toBeInTheDocument()
   })
 
   it('SettingsModal updates the active setup fields', async () => {

--- a/src/pages/gearPlanner/components/gearPlannerParts.test.tsx
+++ b/src/pages/gearPlanner/components/gearPlannerParts.test.tsx
@@ -231,8 +231,7 @@ describe('Gear planner extracted UI parts', () => {
             [itemId]: !prev[itemId]
           }))
         },
-        allItemCardsCollapsed: false,
-        setAllItemCardsCollapsed: vi.fn()
+        allItemCardsCollapsed: false
       })
 
       return <Provider store={store}>{renderSlot(GearSlot.Head, activeSetup)}</Provider>

--- a/src/pages/gearPlanner/hooks/renderGearPlanner.tsx
+++ b/src/pages/gearPlanner/hooks/renderGearPlanner.tsx
@@ -76,6 +76,42 @@ const getApplicableAugments = (augmentSlot: GearAugmentSlot, allAugments: GearAu
   return { groups, sortedGroupNames }
 }
 
+const detailSectionClassName = 'text-start mt-1 pt-1 border-top'
+const detailSectionStyle = { fontSize: '0.65rem' }
+
+const DetailSection = ({
+  children,
+  className = detailSectionClassName
+}: {
+  children: ReactNode
+  className?: string
+}) => (
+  <div className={className} style={detailSectionStyle}>
+    {children}
+  </div>
+)
+
+interface SlotCardState {
+  selectedItem: GearItem
+  slot: GearSlot
+  setup: GearSetup
+  entityState: EntityGearState
+  itemCardCollapsed: boolean
+  displayEnchantments: LootEnchantment[]
+  effectiveAugments: GearAugmentSlot[]
+  currentSlottedAugments: Record<string, Record<number, GearAugment | null>>
+  currentSlottedNearlyFinished: Record<string, LootEnchantment | null>
+  currentSlottedAlmostThere: Record<string, LootEnchantment | null>
+  currentSlottedFinishingTouch: Record<string, LootEnchantment | null>
+  currentSlottedFountainOfNecroticMight: Record<string, boolean>
+  currentSlottedStormreaverUpgrade: Record<string, boolean>
+  currentSlottedZhentarimAttuned: Record<string, boolean>
+  currentSlottedReaperForge: Record<string, string | null>
+  currentSlottedRitualTable: Record<string, LootEnchantment | null>
+  currentSlottedLostPurpose: Record<string, LootEnchantment | null>
+  currentSlottedTraceOfMadness: Record<string, LootEnchantment | null>
+}
+
 export const renderGearPlanner = (props: Props) => {
   const {
     activeSetup,
@@ -152,270 +188,224 @@ export const renderGearPlanner = (props: Props) => {
     </>
   )
 
-  const renderSelectedItemBody = (args: {
-    selectedItem: GearItem
-    slot: GearSlot
-    setup: GearSetup
-    entityState: EntityGearState
-    itemCardCollapsed: boolean
-    displayEnchantments: LootEnchantment[]
-    effectiveAugments: GearAugmentSlot[]
-    currentSlottedAugments: Record<string, Record<number, GearAugment | null>>
-    currentSlottedNearlyFinished: Record<string, LootEnchantment | null>
-    currentSlottedAlmostThere: Record<string, LootEnchantment | null>
-    currentSlottedFinishingTouch: Record<string, LootEnchantment | null>
-    currentSlottedFountainOfNecroticMight: Record<string, boolean>
-    currentSlottedStormreaverUpgrade: Record<string, boolean>
-    currentSlottedZhentarimAttuned: Record<string, boolean>
-    currentSlottedReaperForge: Record<string, string | null>
-    currentSlottedRitualTable: Record<string, LootEnchantment | null>
-    currentSlottedLostPurpose: Record<string, LootEnchantment | null>
-    currentSlottedTraceOfMadness: Record<string, LootEnchantment | null>
-  }) => {
-    const {
-      selectedItem,
-      slot,
-      setup,
-      entityState,
-      itemCardCollapsed,
-      displayEnchantments,
-      effectiveAugments,
-      currentSlottedAugments,
-      currentSlottedNearlyFinished,
-      currentSlottedAlmostThere,
-      currentSlottedFinishingTouch,
-      currentSlottedFountainOfNecroticMight,
-      currentSlottedStormreaverUpgrade,
-      currentSlottedZhentarimAttuned,
-      currentSlottedReaperForge,
-      currentSlottedRitualTable,
-      currentSlottedLostPurpose,
-      currentSlottedTraceOfMadness
-    } = args
+  const renderSelectedItemBody = (state: SlotCardState) => {
+    const currentSlottedAugmentsForItem: Record<number, GearAugment | null> =
+      state.currentSlottedAugments[state.selectedItem.id] ?? {}
 
     return (
       <div className='w-100 d-flex flex-column'>
         <div className='flex-grow-1 text-center w-100 d-flex flex-column'>
-          {renderItemNameAndDrop(selectedItem)}
-          {renderItemMetadata(selectedItem)}
+          {renderItemNameAndDrop(state.selectedItem)}
+          {renderItemMetadata(state.selectedItem)}
 
-          {!itemCardCollapsed && (
+          {!state.itemCardCollapsed && (
             <>
-              {selectedItem.name.includes('Gem of Many Facets') && (
+              {state.selectedItem.name.includes('Gem of Many Facets') && (
                 <GemSetBonusSelector
-                  selectedItem={selectedItem}
-                  activeSetup={setup}
-                  slot={slot}
+                  selectedItem={state.selectedItem}
+                  activeSetup={state.setup}
+                  slot={state.slot}
                   setSlottedGemSetBonus={setSlottedGemSetBonus}
                 />
               )}
 
               <ItemSetBonusDisplay
-                selectedItem={selectedItem}
-                activeSetup={setup}
+                selectedItem={state.selectedItem}
+                activeSetup={state.setup}
                 openSetBonusBrowser={(setName: string) => {
-                  openSetBonusBrowser(setName, slot)
+                  openSetBonusBrowser(setName, state.slot)
                 }}
               />
 
-              {(getMaxFiligreeSlots(selectedItem) > 0 || isMinorArtifact(selectedItem)) && (
-                <FiligreeLabel item={selectedItem} setup={setup} slot={slot} />
+              {(getMaxFiligreeSlots(state.selectedItem) > 0 || isMinorArtifact(state.selectedItem)) && (
+                <FiligreeLabel item={state.selectedItem} setup={state.setup} slot={state.slot} />
               )}
 
-              {Array.isArray(displayEnchantments) && displayEnchantments.length > 0 && (
-                <div
-                  className='text-start mt-1 pt-1 border-top gear-planner-slot-enchantments'
-                  style={{ fontSize: '0.65rem' }}
-                >
+              {Array.isArray(state.displayEnchantments) && state.displayEnchantments.length > 0 && (
+                <DetailSection className='text-start mt-1 pt-1 border-top gear-planner-slot-enchantments'>
                   <EnchantmentList
-                    enchantments={displayEnchantments}
-                    entityState={entityState}
-                    itemId={selectedItem.id}
+                    enchantments={state.displayEnchantments}
+                    entityState={state.entityState}
+                    itemId={state.selectedItem.id}
                     source='slot'
                   />
-                </div>
+                </DetailSection>
               )}
 
-              {effectiveAugments.length > 0 && (
-                <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
-                  {effectiveAugments.map((augmentSlot: GearAugmentSlot, idx: number) => {
+              {state.effectiveAugments.length > 0 && (
+                <DetailSection>
+                  {state.effectiveAugments.map((augmentSlot: GearAugmentSlot, idx: number) => {
                     const applicable = getApplicableAugments(augmentSlot, allAugments)
 
                     return (
                       <AugmentSlotItem
                         key={`${String(augmentSlot.name)} ${String(idx)}`}
-                        selectedItem={selectedItem}
+                        selectedItem={state.selectedItem}
                         idx={idx}
                         augSlot={augmentSlot}
-                        slotted={
-                          selectedItem.id in currentSlottedAugments
-                            ? currentSlottedAugments[selectedItem.id][idx]
-                            : null
-                        }
+                        slotted={currentSlottedAugmentsForItem[idx] ?? null}
                         applicable={applicable}
-                        slot={slot}
-                        entityState={entityState}
+                        slot={state.slot}
+                        entityState={state.entityState}
                         setSlottedAugment={setSlottedAugment}
                         openSetBonusBrowser={openSetBonusBrowser}
                       />
                     )
                   })}
-                </div>
+                </DetailSection>
               )}
 
-              {selectedItem.essenceSlots && selectedItem.essenceSlots.length > 0 && (
-                <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
+              {(state.selectedItem.essenceSlots?.length ?? 0) > 0 && (
+                <DetailSection>
                   <EssenceCraftingSelector
-                    selectedItem={selectedItem}
-                    activeSetup={setup}
-                    slot={slot}
+                    selectedItem={state.selectedItem}
+                    activeSetup={state.setup}
+                    slot={state.slot}
                     setEssenceEnchantment={setEssenceEnchantment}
                     setItemMinLevel={setItemMinLevel}
                     setItemMaterial={setItemMaterial}
                     essenceEnchantments={essenceEnchantments}
-                    entityState={entityState}
+                    entityState={state.entityState}
                   />
-                </div>
+                </DetailSection>
               )}
 
               <NearlyFinishedSelector
-                item={selectedItem}
-                slot={slot}
-                selectedEnchantment={currentSlottedNearlyFinished[selectedItem.id] ?? null}
+                item={state.selectedItem}
+                slot={state.slot}
+                selectedEnchantment={state.currentSlottedNearlyFinished[state.selectedItem.id] ?? null}
                 onSelect={(enchantment: LootEnchantment | null) => {
-                  setNearlyFinishedEnchantment(selectedItem.id, enchantment, slot)
+                  setNearlyFinishedEnchantment(state.selectedItem.id, enchantment, state.slot)
                 }}
-                entityState={entityState}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                entityState={state.entityState}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
               <AlmostThereSelector
-                item={selectedItem}
-                slot={slot}
-                selectedEnchantment={currentSlottedAlmostThere[selectedItem.id] ?? null}
+                item={state.selectedItem}
+                slot={state.slot}
+                selectedEnchantment={state.currentSlottedAlmostThere[state.selectedItem.id] ?? null}
                 onSelect={(enchantment: LootEnchantment | null) => {
-                  setAlmostThereEnchantment(selectedItem.id, enchantment, slot)
+                  setAlmostThereEnchantment(state.selectedItem.id, enchantment, state.slot)
                 }}
-                entityState={entityState}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                entityState={state.entityState}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
               <FinishingTouchSelector
-                item={selectedItem}
-                slot={slot}
-                selectedEnchantment={currentSlottedFinishingTouch[selectedItem.id] ?? null}
+                item={state.selectedItem}
+                slot={state.slot}
+                selectedEnchantment={state.currentSlottedFinishingTouch[state.selectedItem.id] ?? null}
                 onSelect={(enchantment: LootEnchantment | null) => {
-                  setFinishingTouchEnchantment(selectedItem.id, enchantment, slot)
+                  setFinishingTouchEnchantment(state.selectedItem.id, enchantment, state.slot)
                 }}
-                entityState={entityState}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                entityState={state.entityState}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
               <FountainOfNecroticMightSelector
-                item={selectedItem}
-                slot={slot}
-                active={currentSlottedFountainOfNecroticMight[selectedItem.id] || false}
+                item={state.selectedItem}
+                slot={state.slot}
+                active={state.currentSlottedFountainOfNecroticMight[state.selectedItem.id] || false}
                 onToggle={(active: boolean) => {
-                  setFountainOfNecroticMight(selectedItem.id, active, slot)
+                  setFountainOfNecroticMight(state.selectedItem.id, active, state.slot)
                 }}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
               <StormreaverUpgradeSelector
-                item={selectedItem}
-                slot={slot}
-                active={currentSlottedStormreaverUpgrade[selectedItem.id] || false}
+                item={state.selectedItem}
+                slot={state.slot}
+                active={state.currentSlottedStormreaverUpgrade[state.selectedItem.id] || false}
                 onToggle={(active: boolean) => {
-                  setStormreaverUpgrade(selectedItem.id, active, slot)
+                  setStormreaverUpgrade(state.selectedItem.id, active, state.slot)
                 }}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
               <ZhentarimAttunedSelector
-                item={selectedItem}
-                slot={slot}
-                active={currentSlottedZhentarimAttuned[selectedItem.id] || false}
+                item={state.selectedItem}
+                slot={state.slot}
+                active={state.currentSlottedZhentarimAttuned[state.selectedItem.id] || false}
                 onToggle={(active: boolean) => {
-                  setZhentarimAttuned(selectedItem.id, active, slot)
+                  setZhentarimAttuned(state.selectedItem.id, active, state.slot)
                 }}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
               <ReaperForgeSelector
-                item={selectedItem}
-                slot={slot}
-                selectedEffectId={currentSlottedReaperForge[selectedItem.id] ?? null}
+                item={state.selectedItem}
+                slot={state.slot}
+                selectedEffectId={state.currentSlottedReaperForge[state.selectedItem.id] ?? null}
                 onSelectEffect={(effectId: string | null) => {
-                  setReaperForge(selectedItem.id, effectId, slot)
+                  setReaperForge(state.selectedItem.id, effectId, state.slot)
                 }}
-                entityState={entityState}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                entityState={state.entityState}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
               <RitualTableSelector
-                item={selectedItem}
-                slot={slot}
-                selectedEnchantment={currentSlottedRitualTable[selectedItem.id] ?? null}
+                item={state.selectedItem}
+                slot={state.slot}
+                selectedEnchantment={state.currentSlottedRitualTable[state.selectedItem.id] ?? null}
                 onSelect={(enchantment: LootEnchantment | null) => {
-                  setRitualTableEnchantment(selectedItem.id, enchantment, slot)
+                  setRitualTableEnchantment(state.selectedItem.id, enchantment, state.slot)
                 }}
                 troveData={troveData}
-                entityState={entityState}
-                wrapperClassName='text-start mt-1 pt-1 border-top'
-                wrapperStyle={{ fontSize: '0.65rem' }}
+                entityState={state.entityState}
+                wrapperClassName={detailSectionClassName}
+                wrapperStyle={detailSectionStyle}
               />
 
-              {Array.isArray(selectedItem.enchantments) &&
-                selectedItem.enchantments.some(
-                  (enchantment: LootEnchantment) => enchantment.name === 'Lost Purpose'
-                ) && (
-                  <LostPurposeSelector
-                    item={selectedItem}
-                    slot={slot}
-                    selectedEnchantment={currentSlottedLostPurpose[selectedItem.id] ?? null}
-                    onSelect={(enchantment: LootEnchantment | null) => {
-                      setLostPurposeEnchantment(selectedItem.id, enchantment, slot)
-                    }}
-                    entityState={entityState}
-                    wrapperClassName='text-start mt-1 pt-1 border-top'
-                    wrapperStyle={{ fontSize: '0.65rem' }}
-                  />
-                )}
+              {state.selectedItem.enchantments?.some(
+                (enchantment: LootEnchantment) => enchantment.name === 'Lost Purpose'
+              ) && (
+                <LostPurposeSelector
+                  item={state.selectedItem}
+                  slot={state.slot}
+                  selectedEnchantment={state.currentSlottedLostPurpose[state.selectedItem.id] ?? null}
+                  onSelect={(enchantment: LootEnchantment | null) => {
+                    setLostPurposeEnchantment(state.selectedItem.id, enchantment, state.slot)
+                  }}
+                  entityState={state.entityState}
+                  wrapperClassName={detailSectionClassName}
+                  wrapperStyle={detailSectionStyle}
+                />
+              )}
 
-              {Array.isArray(selectedItem.enchantments) &&
-                selectedItem.enchantments.some(
-                  (enchantment: LootEnchantment) => enchantment.name === 'Trace of Madness'
-                ) && (
-                  <TraceOfMadnessSelector
-                    item={selectedItem}
-                    slot={slot}
-                    selectedEnchantment={currentSlottedTraceOfMadness[selectedItem.id] ?? null}
-                    onSelect={(enchantment: LootEnchantment | null) => {
-                      setTraceOfMadnessEnchantment(selectedItem.id, enchantment, slot)
-                    }}
-                    entityState={entityState}
-                    wrapperClassName='text-start mt-1 pt-1 border-top'
-                    wrapperStyle={{ fontSize: '0.65rem' }}
-                  />
-                )}
+              {state.selectedItem.enchantments?.some(
+                (enchantment: LootEnchantment) => enchantment.name === 'Trace of Madness'
+              ) && (
+                <TraceOfMadnessSelector
+                  item={state.selectedItem}
+                  slot={state.slot}
+                  selectedEnchantment={state.currentSlottedTraceOfMadness[state.selectedItem.id] ?? null}
+                  onSelect={(enchantment: LootEnchantment | null) => {
+                    setTraceOfMadnessEnchantment(state.selectedItem.id, enchantment, state.slot)
+                  }}
+                  entityState={state.entityState}
+                  wrapperClassName={detailSectionClassName}
+                  wrapperStyle={detailSectionStyle}
+                />
+              )}
 
-              <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
+              <DetailSection>
                 <CurseSlotItem
-                  selectedItem={selectedItem}
+                  selectedItem={state.selectedItem}
                   allCurses={allCurses}
-                  slotted={setup.slottedCurses[selectedItem.id]}
-                  slot={slot}
-                  entityState={entityState}
+                  slotted={state.setup.slottedCurses[state.selectedItem.id]}
+                  slot={state.slot}
+                  entityState={state.entityState}
                   setCurse={setSlottedCurse}
                 />
-              </div>
+              </DetailSection>
             </>
           )}
         </div>
@@ -423,114 +413,46 @@ export const renderGearPlanner = (props: Props) => {
     )
   }
 
-  const renderSlotCard = (args: {
-    slot: GearSlot
-    selectedItem: GearItem | null
-    itemCardCollapsed: boolean
-    entityState: EntityGearState
-    setup: GearSetup
-    displayEnchantments: LootEnchantment[]
-    effectiveAugments: GearAugmentSlot[]
-    currentSlottedAugments: Record<string, Record<number, GearAugment | null>>
-    currentSlottedNearlyFinished: Record<string, LootEnchantment | null>
-    currentSlottedAlmostThere: Record<string, LootEnchantment | null>
-    currentSlottedFinishingTouch: Record<string, LootEnchantment | null>
-    currentSlottedFountainOfNecroticMight: Record<string, boolean>
-    currentSlottedStormreaverUpgrade: Record<string, boolean>
-    currentSlottedZhentarimAttuned: Record<string, boolean>
-    currentSlottedReaperForge: Record<string, string | null>
-    currentSlottedRitualTable: Record<string, LootEnchantment | null>
-    currentSlottedLostPurpose: Record<string, LootEnchantment | null>
-    currentSlottedTraceOfMadness: Record<string, LootEnchantment | null>
-  }) => {
-    const {
-      slot,
-      selectedItem,
-      itemCardCollapsed,
-      entityState,
-      setup,
-      displayEnchantments,
-      effectiveAugments,
-      currentSlottedAugments,
-      currentSlottedNearlyFinished,
-      currentSlottedAlmostThere,
-      currentSlottedFinishingTouch,
-      currentSlottedFountainOfNecroticMight,
-      currentSlottedStormreaverUpgrade,
-      currentSlottedZhentarimAttuned,
-      currentSlottedReaperForge,
-      currentSlottedRitualTable,
-      currentSlottedLostPurpose,
-      currentSlottedTraceOfMadness
-    } = args
-
+  const renderSlotCard = (state: SlotCardState) => {
     return (
-      <Col key={slot} xs={12} sm={6} md={4} lg={3} className='mb-3 px-1'>
-        <Card className={`h-100 shadow-sm ${selectedItem ? 'border-primary' : ''} position-relative`}>
+      <Col key={state.slot} xs={12} sm={6} md={4} lg={3} className='mb-3 px-1'>
+        <Card className='h-100 shadow-sm border-primary position-relative'>
           <Card.Header className='p-0 bg-secondary-subtle text-secondary-emphasis small fw-bold d-flex align-items-stretch'>
             <Button
               variant='link'
               type='button'
-              className={`gear-planner-slot-header-main d-flex align-items-center justify-content-between gap-2 text-secondary-emphasis text-decoration-none text-start rounded-0 border-0 shadow-none ${
-                selectedItem ? '' : 'gear-planner-slot-header-main-alone'
-              }`}
+              className='gear-planner-slot-header-main d-flex align-items-center justify-content-between gap-2 text-secondary-emphasis text-decoration-none text-start rounded-0 border-0 shadow-none'
               onClick={() => {
-                openSlotBrowser(slot)
+                openSlotBrowser(state.slot)
               }}
             >
               <span className='d-flex align-items-center gap-2 min-w-0'>
-                <span className='gear-planner-slot-header-label text-truncate'>{slot}</span>
-                {selectedItem && <TroveBadge itemName={selectedItem.name} troveData={troveData} />}
+                <span className='gear-planner-slot-header-label text-truncate'>{state.slot}</span>
+                <TroveBadge itemName={state.selectedItem.name} troveData={troveData} />
               </span>
 
               <FaMagnifyingGlass className='text-muted flex-shrink-0' size={12} />
             </Button>
 
-            {selectedItem && (
-              <Button
-                variant='link'
-                type='button'
-                className='gear-planner-slot-header-collapse flex-shrink-0 text-secondary-emphasis text-decoration-none rounded-0 border-start border-0 shadow-none'
-                aria-label={itemCardCollapsed ? `Expand ${selectedItem.name}` : `Collapse ${selectedItem.name}`}
-                title={itemCardCollapsed ? 'Expand card' : 'Collapse card'}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  toggleItemCardCollapsed(selectedItem.id)
-                }}
-              >
-                {itemCardCollapsed ? <FaChevronRight size={10} /> : <FaChevronDown size={10} />}
-              </Button>
-            )}
+            <Button
+              variant='link'
+              type='button'
+              className='gear-planner-slot-header-collapse flex-shrink-0 text-secondary-emphasis text-decoration-none rounded-0 border-start border-0 shadow-none'
+              aria-label={
+                state.itemCardCollapsed ? `Expand ${state.selectedItem.name}` : `Collapse ${state.selectedItem.name}`
+              }
+              title={state.itemCardCollapsed ? 'Expand card' : 'Collapse card'}
+              onClick={(e) => {
+                e.stopPropagation()
+                toggleItemCardCollapsed(state.selectedItem.id)
+              }}
+            >
+              {state.itemCardCollapsed ? <FaChevronRight size={10} /> : <FaChevronDown size={10} />}
+            </Button>
           </Card.Header>
 
-          <Card.Body
-            className={`p-2 d-flex flex-column align-items-center ${selectedItem ? 'bg-white' : 'bg-dark-subtle justify-content-center'}`}
-            style={{ minHeight: '100px' }}
-          >
-            {selectedItem ? (
-              renderSelectedItemBody({
-                selectedItem,
-                slot,
-                setup,
-                entityState,
-                itemCardCollapsed,
-                displayEnchantments,
-                effectiveAugments,
-                currentSlottedAugments,
-                currentSlottedNearlyFinished,
-                currentSlottedAlmostThere,
-                currentSlottedFinishingTouch,
-                currentSlottedFountainOfNecroticMight,
-                currentSlottedStormreaverUpgrade,
-                currentSlottedZhentarimAttuned,
-                currentSlottedReaperForge,
-                currentSlottedRitualTable,
-                currentSlottedLostPurpose,
-                currentSlottedTraceOfMadness
-              })
-            ) : (
-              <div className='text-center italic small text-secondary'>No Item Selected</div>
-            )}
+          <Card.Body className='p-2 d-flex flex-column align-items-center bg-white' style={{ minHeight: '100px' }}>
+            {renderSelectedItemBody(state)}
           </Card.Body>
         </Card>
       </Col>
@@ -571,6 +493,38 @@ export const renderGearPlanner = (props: Props) => {
       : false
     const effectiveAugments =
       nfAddedAugments && hasAnyNFUpgradeActive ? nfAddedAugments : (selectedItem?.augments ?? [])
+
+    if (!selectedItem) {
+      return (
+        <Col key={slot} xs={12} sm={6} md={4} lg={3} className='mb-3 px-1'>
+          <Card className='h-100 shadow-sm position-relative'>
+            <Card.Header className='p-0 bg-secondary-subtle text-secondary-emphasis small fw-bold d-flex align-items-stretch'>
+              <Button
+                variant='link'
+                type='button'
+                className='gear-planner-slot-header-main gear-planner-slot-header-main-alone d-flex align-items-center justify-content-between gap-2 text-secondary-emphasis text-decoration-none text-start rounded-0 border-0 shadow-none'
+                onClick={() => {
+                  openSlotBrowser(slot)
+                }}
+              >
+                <span className='d-flex align-items-center gap-2 min-w-0'>
+                  <span className='gear-planner-slot-header-label text-truncate'>{slot}</span>
+                </span>
+
+                <FaMagnifyingGlass className='text-muted flex-shrink-0' size={12} />
+              </Button>
+            </Card.Header>
+
+            <Card.Body
+              className='p-2 d-flex flex-column align-items-center bg-dark-subtle justify-content-center'
+              style={{ minHeight: '100px' }}
+            >
+              <div className='text-center italic small text-secondary'>No Item Selected</div>
+            </Card.Body>
+          </Card>
+        </Col>
+      )
+    }
 
     return renderSlotCard({
       slot,

--- a/src/pages/gearPlanner/hooks/renderGearPlanner.tsx
+++ b/src/pages/gearPlanner/hooks/renderGearPlanner.tsx
@@ -1,6 +1,6 @@
 import { type JSX, type ReactNode } from 'react'
-import { Card, Col } from 'react-bootstrap'
-import { FaMagnifyingGlass } from 'react-icons/fa6'
+import { Button, Card, Col } from 'react-bootstrap'
+import { FaChevronDown, FaChevronRight, FaMagnifyingGlass } from 'react-icons/fa6'
 import type { ItemRollup } from '../../../components/trove/types.ts'
 import { SLOT_GROUPS } from '../../../utils/augmentUtils.ts'
 import AlmostThereSelector from '../components/AlmostThereSelector'
@@ -103,7 +103,9 @@ export const renderGearPlanner = (props: Props) => {
     setFountainOfNecroticMight,
     setStormreaverUpgrade,
     setZhentarimAttuned,
-    setReaperForge
+    setReaperForge,
+    isItemCardCollapsed,
+    toggleItemCardCollapsed
   } = props
 
   const renderItemNameAndDrop = (item: GearItem) => (
@@ -150,6 +152,391 @@ export const renderGearPlanner = (props: Props) => {
     </>
   )
 
+  const renderSelectedItemBody = (args: {
+    selectedItem: GearItem
+    slot: GearSlot
+    setup: GearSetup
+    entityState: EntityGearState
+    itemCardCollapsed: boolean
+    displayEnchantments: LootEnchantment[]
+    effectiveAugments: GearAugmentSlot[]
+    currentSlottedAugments: Record<string, Record<number, GearAugment | null>>
+    currentSlottedNearlyFinished: Record<string, LootEnchantment | null>
+    currentSlottedAlmostThere: Record<string, LootEnchantment | null>
+    currentSlottedFinishingTouch: Record<string, LootEnchantment | null>
+    currentSlottedFountainOfNecroticMight: Record<string, boolean>
+    currentSlottedStormreaverUpgrade: Record<string, boolean>
+    currentSlottedZhentarimAttuned: Record<string, boolean>
+    currentSlottedReaperForge: Record<string, string | null>
+    currentSlottedRitualTable: Record<string, LootEnchantment | null>
+    currentSlottedLostPurpose: Record<string, LootEnchantment | null>
+    currentSlottedTraceOfMadness: Record<string, LootEnchantment | null>
+  }) => {
+    const {
+      selectedItem,
+      slot,
+      setup,
+      entityState,
+      itemCardCollapsed,
+      displayEnchantments,
+      effectiveAugments,
+      currentSlottedAugments,
+      currentSlottedNearlyFinished,
+      currentSlottedAlmostThere,
+      currentSlottedFinishingTouch,
+      currentSlottedFountainOfNecroticMight,
+      currentSlottedStormreaverUpgrade,
+      currentSlottedZhentarimAttuned,
+      currentSlottedReaperForge,
+      currentSlottedRitualTable,
+      currentSlottedLostPurpose,
+      currentSlottedTraceOfMadness
+    } = args
+
+    return (
+      <div className='w-100 d-flex flex-column'>
+        <div className='flex-grow-1 text-center w-100 d-flex flex-column'>
+          {renderItemNameAndDrop(selectedItem)}
+          {renderItemMetadata(selectedItem)}
+
+          {!itemCardCollapsed && (
+            <>
+              {selectedItem.name.includes('Gem of Many Facets') && (
+                <GemSetBonusSelector
+                  selectedItem={selectedItem}
+                  activeSetup={setup}
+                  slot={slot}
+                  setSlottedGemSetBonus={setSlottedGemSetBonus}
+                />
+              )}
+
+              <ItemSetBonusDisplay
+                selectedItem={selectedItem}
+                activeSetup={setup}
+                openSetBonusBrowser={(setName: string) => {
+                  openSetBonusBrowser(setName, slot)
+                }}
+              />
+
+              {(getMaxFiligreeSlots(selectedItem) > 0 || isMinorArtifact(selectedItem)) && (
+                <FiligreeLabel item={selectedItem} setup={setup} slot={slot} />
+              )}
+
+              {Array.isArray(displayEnchantments) && displayEnchantments.length > 0 && (
+                <div
+                  className='text-start mt-1 pt-1 border-top gear-planner-slot-enchantments'
+                  style={{ fontSize: '0.65rem' }}
+                >
+                  <EnchantmentList
+                    enchantments={displayEnchantments}
+                    entityState={entityState}
+                    itemId={selectedItem.id}
+                    source='slot'
+                  />
+                </div>
+              )}
+
+              {effectiveAugments.length > 0 && (
+                <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
+                  {effectiveAugments.map((augmentSlot: GearAugmentSlot, idx: number) => {
+                    const applicable = getApplicableAugments(augmentSlot, allAugments)
+
+                    return (
+                      <AugmentSlotItem
+                        key={`${String(augmentSlot.name)} ${String(idx)}`}
+                        selectedItem={selectedItem}
+                        idx={idx}
+                        augSlot={augmentSlot}
+                        slotted={
+                          selectedItem.id in currentSlottedAugments
+                            ? currentSlottedAugments[selectedItem.id][idx]
+                            : null
+                        }
+                        applicable={applicable}
+                        slot={slot}
+                        entityState={entityState}
+                        setSlottedAugment={setSlottedAugment}
+                        openSetBonusBrowser={openSetBonusBrowser}
+                      />
+                    )
+                  })}
+                </div>
+              )}
+
+              {selectedItem.essenceSlots && selectedItem.essenceSlots.length > 0 && (
+                <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
+                  <EssenceCraftingSelector
+                    selectedItem={selectedItem}
+                    activeSetup={setup}
+                    slot={slot}
+                    setEssenceEnchantment={setEssenceEnchantment}
+                    setItemMinLevel={setItemMinLevel}
+                    setItemMaterial={setItemMaterial}
+                    essenceEnchantments={essenceEnchantments}
+                    entityState={entityState}
+                  />
+                </div>
+              )}
+
+              <NearlyFinishedSelector
+                item={selectedItem}
+                slot={slot}
+                selectedEnchantment={currentSlottedNearlyFinished[selectedItem.id] ?? null}
+                onSelect={(enchantment: LootEnchantment | null) => {
+                  setNearlyFinishedEnchantment(selectedItem.id, enchantment, slot)
+                }}
+                entityState={entityState}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              <AlmostThereSelector
+                item={selectedItem}
+                slot={slot}
+                selectedEnchantment={currentSlottedAlmostThere[selectedItem.id] ?? null}
+                onSelect={(enchantment: LootEnchantment | null) => {
+                  setAlmostThereEnchantment(selectedItem.id, enchantment, slot)
+                }}
+                entityState={entityState}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              <FinishingTouchSelector
+                item={selectedItem}
+                slot={slot}
+                selectedEnchantment={currentSlottedFinishingTouch[selectedItem.id] ?? null}
+                onSelect={(enchantment: LootEnchantment | null) => {
+                  setFinishingTouchEnchantment(selectedItem.id, enchantment, slot)
+                }}
+                entityState={entityState}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              <FountainOfNecroticMightSelector
+                item={selectedItem}
+                slot={slot}
+                active={currentSlottedFountainOfNecroticMight[selectedItem.id] || false}
+                onToggle={(active: boolean) => {
+                  setFountainOfNecroticMight(selectedItem.id, active, slot)
+                }}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              <StormreaverUpgradeSelector
+                item={selectedItem}
+                slot={slot}
+                active={currentSlottedStormreaverUpgrade[selectedItem.id] || false}
+                onToggle={(active: boolean) => {
+                  setStormreaverUpgrade(selectedItem.id, active, slot)
+                }}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              <ZhentarimAttunedSelector
+                item={selectedItem}
+                slot={slot}
+                active={currentSlottedZhentarimAttuned[selectedItem.id] || false}
+                onToggle={(active: boolean) => {
+                  setZhentarimAttuned(selectedItem.id, active, slot)
+                }}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              <ReaperForgeSelector
+                item={selectedItem}
+                slot={slot}
+                selectedEffectId={currentSlottedReaperForge[selectedItem.id] ?? null}
+                onSelectEffect={(effectId: string | null) => {
+                  setReaperForge(selectedItem.id, effectId, slot)
+                }}
+                entityState={entityState}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              <RitualTableSelector
+                item={selectedItem}
+                slot={slot}
+                selectedEnchantment={currentSlottedRitualTable[selectedItem.id] ?? null}
+                onSelect={(enchantment: LootEnchantment | null) => {
+                  setRitualTableEnchantment(selectedItem.id, enchantment, slot)
+                }}
+                troveData={troveData}
+                entityState={entityState}
+                wrapperClassName='text-start mt-1 pt-1 border-top'
+                wrapperStyle={{ fontSize: '0.65rem' }}
+              />
+
+              {Array.isArray(selectedItem.enchantments) &&
+                selectedItem.enchantments.some(
+                  (enchantment: LootEnchantment) => enchantment.name === 'Lost Purpose'
+                ) && (
+                  <LostPurposeSelector
+                    item={selectedItem}
+                    slot={slot}
+                    selectedEnchantment={currentSlottedLostPurpose[selectedItem.id] ?? null}
+                    onSelect={(enchantment: LootEnchantment | null) => {
+                      setLostPurposeEnchantment(selectedItem.id, enchantment, slot)
+                    }}
+                    entityState={entityState}
+                    wrapperClassName='text-start mt-1 pt-1 border-top'
+                    wrapperStyle={{ fontSize: '0.65rem' }}
+                  />
+                )}
+
+              {Array.isArray(selectedItem.enchantments) &&
+                selectedItem.enchantments.some(
+                  (enchantment: LootEnchantment) => enchantment.name === 'Trace of Madness'
+                ) && (
+                  <TraceOfMadnessSelector
+                    item={selectedItem}
+                    slot={slot}
+                    selectedEnchantment={currentSlottedTraceOfMadness[selectedItem.id] ?? null}
+                    onSelect={(enchantment: LootEnchantment | null) => {
+                      setTraceOfMadnessEnchantment(selectedItem.id, enchantment, slot)
+                    }}
+                    entityState={entityState}
+                    wrapperClassName='text-start mt-1 pt-1 border-top'
+                    wrapperStyle={{ fontSize: '0.65rem' }}
+                  />
+                )}
+
+              <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
+                <CurseSlotItem
+                  selectedItem={selectedItem}
+                  allCurses={allCurses}
+                  slotted={setup.slottedCurses[selectedItem.id]}
+                  slot={slot}
+                  entityState={entityState}
+                  setCurse={setSlottedCurse}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const renderSlotCard = (args: {
+    slot: GearSlot
+    selectedItem: GearItem | null
+    itemCardCollapsed: boolean
+    entityState: EntityGearState
+    setup: GearSetup
+    displayEnchantments: LootEnchantment[]
+    effectiveAugments: GearAugmentSlot[]
+    currentSlottedAugments: Record<string, Record<number, GearAugment | null>>
+    currentSlottedNearlyFinished: Record<string, LootEnchantment | null>
+    currentSlottedAlmostThere: Record<string, LootEnchantment | null>
+    currentSlottedFinishingTouch: Record<string, LootEnchantment | null>
+    currentSlottedFountainOfNecroticMight: Record<string, boolean>
+    currentSlottedStormreaverUpgrade: Record<string, boolean>
+    currentSlottedZhentarimAttuned: Record<string, boolean>
+    currentSlottedReaperForge: Record<string, string | null>
+    currentSlottedRitualTable: Record<string, LootEnchantment | null>
+    currentSlottedLostPurpose: Record<string, LootEnchantment | null>
+    currentSlottedTraceOfMadness: Record<string, LootEnchantment | null>
+  }) => {
+    const {
+      slot,
+      selectedItem,
+      itemCardCollapsed,
+      entityState,
+      setup,
+      displayEnchantments,
+      effectiveAugments,
+      currentSlottedAugments,
+      currentSlottedNearlyFinished,
+      currentSlottedAlmostThere,
+      currentSlottedFinishingTouch,
+      currentSlottedFountainOfNecroticMight,
+      currentSlottedStormreaverUpgrade,
+      currentSlottedZhentarimAttuned,
+      currentSlottedReaperForge,
+      currentSlottedRitualTable,
+      currentSlottedLostPurpose,
+      currentSlottedTraceOfMadness
+    } = args
+
+    return (
+      <Col key={slot} xs={12} sm={6} md={4} lg={3} className='mb-3 px-1'>
+        <Card className={`h-100 shadow-sm ${selectedItem ? 'border-primary' : ''} position-relative`}>
+          <Card.Header className='p-0 bg-secondary-subtle text-secondary-emphasis small fw-bold d-flex align-items-stretch'>
+            <Button
+              variant='link'
+              type='button'
+              className={`gear-planner-slot-header-main d-flex align-items-center justify-content-between gap-2 text-secondary-emphasis text-decoration-none text-start rounded-0 border-0 shadow-none ${
+                selectedItem ? '' : 'gear-planner-slot-header-main-alone'
+              }`}
+              onClick={() => {
+                openSlotBrowser(slot)
+              }}
+            >
+              <span className='d-flex align-items-center gap-2 min-w-0'>
+                <span className='gear-planner-slot-header-label text-truncate'>{slot}</span>
+                {selectedItem && <TroveBadge itemName={selectedItem.name} troveData={troveData} />}
+              </span>
+
+              <FaMagnifyingGlass className='text-muted flex-shrink-0' size={12} />
+            </Button>
+
+            {selectedItem && (
+              <Button
+                variant='link'
+                type='button'
+                className='gear-planner-slot-header-collapse flex-shrink-0 text-secondary-emphasis text-decoration-none rounded-0 border-start border-0 shadow-none'
+                aria-label={itemCardCollapsed ? `Expand ${selectedItem.name}` : `Collapse ${selectedItem.name}`}
+                title={itemCardCollapsed ? 'Expand card' : 'Collapse card'}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  toggleItemCardCollapsed(selectedItem.id)
+                }}
+              >
+                {itemCardCollapsed ? <FaChevronRight size={10} /> : <FaChevronDown size={10} />}
+              </Button>
+            )}
+          </Card.Header>
+
+          <Card.Body
+            className={`p-2 d-flex flex-column align-items-center ${selectedItem ? 'bg-white' : 'bg-dark-subtle justify-content-center'}`}
+            style={{ minHeight: '100px' }}
+          >
+            {selectedItem ? (
+              renderSelectedItemBody({
+                selectedItem,
+                slot,
+                setup,
+                entityState,
+                itemCardCollapsed,
+                displayEnchantments,
+                effectiveAugments,
+                currentSlottedAugments,
+                currentSlottedNearlyFinished,
+                currentSlottedAlmostThere,
+                currentSlottedFinishingTouch,
+                currentSlottedFountainOfNecroticMight,
+                currentSlottedStormreaverUpgrade,
+                currentSlottedZhentarimAttuned,
+                currentSlottedReaperForge,
+                currentSlottedRitualTable,
+                currentSlottedLostPurpose,
+                currentSlottedTraceOfMadness
+              })
+            ) : (
+              <div className='text-center italic small text-secondary'>No Item Selected</div>
+            )}
+          </Card.Body>
+        </Card>
+      </Col>
+    )
+  }
+
   const renderSlot = (slot: GearSlot, setup: GearSetup): JSX.Element => {
     const owner: string = getSlotOwner(slot)
     const entityState = getEntityState(owner)
@@ -166,6 +553,7 @@ export const renderGearPlanner = (props: Props) => {
     const currentSlottedStormreaverUpgrade = entityState.slottedStormreaverUpgrade
     const currentSlottedZhentarimAttuned = entityState.slottedZhentarimAttuned
     const currentSlottedReaperForge = entityState.slottedReaperForge
+    const itemCardCollapsed = selectedItem ? isItemCardCollapsed(selectedItem.id) : false
 
     const isFountainUpgraded = selectedItem ? currentSlottedFountainOfNecroticMight[selectedItem.id] : false
     const isStormreaverUpgraded = selectedItem ? currentSlottedStormreaverUpgrade[selectedItem.id] : false
@@ -184,256 +572,26 @@ export const renderGearPlanner = (props: Props) => {
     const effectiveAugments =
       nfAddedAugments && hasAnyNFUpgradeActive ? nfAddedAugments : (selectedItem?.augments ?? [])
 
-    return (
-      <Col key={slot} xs={12} sm={6} md={4} lg={3} className='mb-3 px-1'>
-        <Card className={`h-100 shadow-sm ${selectedItem ? 'border-primary' : ''} position-relative`}>
-          <Card.Header
-            className='py-1 px-2 bg-secondary-subtle text-secondary-emphasis small fw-bold d-flex justify-content-between align-items-center cursor-pointer'
-            onClick={() => {
-              openSlotBrowser(slot)
-            }}
-          >
-            <div className='d-flex align-items-center gap-2'>
-              <span>{slot}</span>
-              {selectedItem && <TroveBadge itemName={selectedItem.name} troveData={troveData} />}
-            </div>
-
-            <FaMagnifyingGlass className='text-muted' size={12} />
-          </Card.Header>
-
-          <Card.Body
-            className={`p-2 d-flex flex-column align-items-center ${selectedItem ? 'bg-white' : 'bg-dark-subtle justify-content-center'}`}
-            style={{ minHeight: '100px' }}
-          >
-            {selectedItem ? (
-              <div className='text-center w-100 d-flex flex-column'>
-                {renderItemNameAndDrop(selectedItem)}
-
-                {selectedItem.name.includes('Gem of Many Facets') && (
-                  <GemSetBonusSelector
-                    selectedItem={selectedItem}
-                    activeSetup={activeSetup}
-                    slot={slot}
-                    setSlottedGemSetBonus={setSlottedGemSetBonus}
-                  />
-                )}
-
-                <ItemSetBonusDisplay
-                  selectedItem={selectedItem}
-                  activeSetup={activeSetup}
-                  openSetBonusBrowser={(setName: string) => {
-                    openSetBonusBrowser(setName, slot)
-                  }}
-                />
-
-                {(getMaxFiligreeSlots(selectedItem) > 0 || isMinorArtifact(selectedItem)) && (
-                  <FiligreeLabel item={selectedItem} setup={activeSetup} slot={slot} />
-                )}
-
-                {renderItemMetadata(selectedItem)}
-
-                {Array.isArray(displayEnchantments) && displayEnchantments.length > 0 && (
-                  <div
-                    className='text-start mt-1 pt-1 border-top gear-planner-slot-enchantments'
-                    style={{ fontSize: '0.65rem' }}
-                  >
-                    <EnchantmentList
-                      enchantments={displayEnchantments}
-                      entityState={entityState}
-                      itemId={selectedItem.id}
-                      source='slot'
-                    />
-                  </div>
-                )}
-
-                {effectiveAugments.length > 0 && (
-                  <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
-                    {effectiveAugments.map((augmentSlot: GearAugmentSlot, idx: number) => {
-                      const applicable = getApplicableAugments(augmentSlot, allAugments)
-
-                      return (
-                        <AugmentSlotItem
-                          key={`${String(augmentSlot.name)} ${String(idx)}`}
-                          selectedItem={selectedItem}
-                          idx={idx}
-                          augSlot={augmentSlot}
-                          slotted={
-                            selectedItem.id in currentSlottedAugments
-                              ? currentSlottedAugments[selectedItem.id][idx]
-                              : null
-                          }
-                          applicable={applicable}
-                          slot={slot}
-                          entityState={entityState}
-                          setSlottedAugment={setSlottedAugment}
-                          openSetBonusBrowser={openSetBonusBrowser}
-                        />
-                      )
-                    })}
-                  </div>
-                )}
-
-                {selectedItem.essenceSlots && selectedItem.essenceSlots.length > 0 && (
-                  <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
-                    <EssenceCraftingSelector
-                      selectedItem={selectedItem}
-                      activeSetup={activeSetup}
-                      slot={slot}
-                      setEssenceEnchantment={setEssenceEnchantment}
-                      setItemMinLevel={setItemMinLevel}
-                      setItemMaterial={setItemMaterial}
-                      essenceEnchantments={essenceEnchantments}
-                      entityState={entityState}
-                    />
-                  </div>
-                )}
-
-                <NearlyFinishedSelector
-                  item={selectedItem}
-                  slot={slot}
-                  selectedEnchantment={currentSlottedNearlyFinished[selectedItem.id] ?? null}
-                  onSelect={(enchantment: LootEnchantment | null) => {
-                    setNearlyFinishedEnchantment(selectedItem.id, enchantment, slot)
-                  }}
-                  entityState={entityState}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                <AlmostThereSelector
-                  item={selectedItem}
-                  slot={slot}
-                  selectedEnchantment={currentSlottedAlmostThere[selectedItem.id] ?? null}
-                  onSelect={(enchantment: LootEnchantment | null) => {
-                    setAlmostThereEnchantment(selectedItem.id, enchantment, slot)
-                  }}
-                  entityState={entityState}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                <FinishingTouchSelector
-                  item={selectedItem}
-                  slot={slot}
-                  selectedEnchantment={currentSlottedFinishingTouch[selectedItem.id] ?? null}
-                  onSelect={(enchantment: LootEnchantment | null) => {
-                    setFinishingTouchEnchantment(selectedItem.id, enchantment, slot)
-                  }}
-                  entityState={entityState}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                <FountainOfNecroticMightSelector
-                  item={selectedItem}
-                  slot={slot}
-                  active={currentSlottedFountainOfNecroticMight[selectedItem.id] || false}
-                  onToggle={(active: boolean) => {
-                    setFountainOfNecroticMight(selectedItem.id, active, slot)
-                  }}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                <StormreaverUpgradeSelector
-                  item={selectedItem}
-                  slot={slot}
-                  active={currentSlottedStormreaverUpgrade[selectedItem.id] || false}
-                  onToggle={(active: boolean) => {
-                    setStormreaverUpgrade(selectedItem.id, active, slot)
-                  }}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                <ZhentarimAttunedSelector
-                  item={selectedItem}
-                  slot={slot}
-                  active={currentSlottedZhentarimAttuned[selectedItem.id] || false}
-                  onToggle={(active: boolean) => {
-                    setZhentarimAttuned(selectedItem.id, active, slot)
-                  }}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                <ReaperForgeSelector
-                  item={selectedItem}
-                  slot={slot}
-                  selectedEffectId={currentSlottedReaperForge[selectedItem.id] ?? null}
-                  onSelectEffect={(effectId: string | null) => {
-                    setReaperForge(selectedItem.id, effectId, slot)
-                  }}
-                  entityState={entityState}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                <RitualTableSelector
-                  item={selectedItem}
-                  slot={slot}
-                  selectedEnchantment={currentSlottedRitualTable[selectedItem.id] ?? null}
-                  onSelect={(enchantment: LootEnchantment | null) => {
-                    setRitualTableEnchantment(selectedItem.id, enchantment, slot)
-                  }}
-                  troveData={troveData}
-                  entityState={entityState}
-                  wrapperClassName='text-start mt-1 pt-1 border-top'
-                  wrapperStyle={{ fontSize: '0.65rem' }}
-                />
-
-                {Array.isArray(selectedItem.enchantments) &&
-                  selectedItem.enchantments.some(
-                    (enchantment: LootEnchantment) => enchantment.name === 'Lost Purpose'
-                  ) && (
-                    <LostPurposeSelector
-                      item={selectedItem}
-                      slot={slot}
-                      selectedEnchantment={currentSlottedLostPurpose[selectedItem.id] ?? null}
-                      onSelect={(enchantment: LootEnchantment | null) => {
-                        setLostPurposeEnchantment(selectedItem.id, enchantment, slot)
-                      }}
-                      entityState={entityState}
-                      wrapperClassName='text-start mt-1 pt-1 border-top'
-                      wrapperStyle={{ fontSize: '0.65rem' }}
-                    />
-                  )}
-
-                {Array.isArray(selectedItem.enchantments) &&
-                  selectedItem.enchantments.some(
-                    (enchantment: LootEnchantment) => enchantment.name === 'Trace of Madness'
-                  ) && (
-                    <TraceOfMadnessSelector
-                      item={selectedItem}
-                      slot={slot}
-                      selectedEnchantment={currentSlottedTraceOfMadness[selectedItem.id] ?? null}
-                      onSelect={(enchantment: LootEnchantment | null) => {
-                        setTraceOfMadnessEnchantment(selectedItem.id, enchantment, slot)
-                      }}
-                      entityState={entityState}
-                      wrapperClassName='text-start mt-1 pt-1 border-top'
-                      wrapperStyle={{ fontSize: '0.65rem' }}
-                    />
-                  )}
-
-                <div className='text-start mt-1 pt-1 border-top' style={{ fontSize: '0.65rem' }}>
-                  <CurseSlotItem
-                    selectedItem={selectedItem}
-                    allCurses={allCurses}
-                    slotted={setup.slottedCurses[selectedItem.id]}
-                    slot={slot}
-                    entityState={entityState}
-                    setCurse={setSlottedCurse}
-                  />
-                </div>
-              </div>
-            ) : (
-              <div className='text-center italic small text-secondary'>No Item Selected</div>
-            )}
-          </Card.Body>
-        </Card>
-      </Col>
-    )
+    return renderSlotCard({
+      slot,
+      selectedItem,
+      itemCardCollapsed,
+      entityState,
+      setup,
+      displayEnchantments,
+      effectiveAugments,
+      currentSlottedAugments,
+      currentSlottedNearlyFinished,
+      currentSlottedAlmostThere,
+      currentSlottedFinishingTouch,
+      currentSlottedFountainOfNecroticMight,
+      currentSlottedStormreaverUpgrade,
+      currentSlottedZhentarimAttuned,
+      currentSlottedReaperForge,
+      currentSlottedRitualTable,
+      currentSlottedLostPurpose,
+      currentSlottedTraceOfMadness
+    })
   }
 
   return { renderSlot }
@@ -466,4 +624,8 @@ interface Props {
   setStormreaverUpgrade: (itemId: string, active: boolean, slot?: GearSlot) => void
   setZhentarimAttuned: (itemId: string, active: boolean, slot?: GearSlot) => void
   setReaperForge: (itemId: string, effectId: string | null, slot?: GearSlot) => void
+  isItemCardCollapsed: (itemId: string) => boolean
+  toggleItemCardCollapsed: (itemId: string) => void
+  allItemCardsCollapsed: boolean
+  setAllItemCardsCollapsed: (collapsed: boolean) => void
 }

--- a/src/pages/gearPlanner/hooks/renderGearPlanner.tsx
+++ b/src/pages/gearPlanner/hooks/renderGearPlanner.tsx
@@ -627,5 +627,4 @@ interface Props {
   isItemCardCollapsed: (itemId: string) => boolean
   toggleItemCardCollapsed: (itemId: string) => void
   allItemCardsCollapsed: boolean
-  setAllItemCardsCollapsed: (collapsed: boolean) => void
 }

--- a/src/pages/gearPlanner/hooks/useGearPlanner.tsx
+++ b/src/pages/gearPlanner/hooks/useGearPlanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useAppSelector } from '../../../redux/hooks'
 import { createDefaultSetup } from '../initialState'
 import type { GearSetup } from '../types.ts'
@@ -63,9 +63,6 @@ const useGearPlanner = (props: Props) => {
     setSetBonusFilter
   } = useGearPlannerUI()
 
-  const formatDropLocations = useFormatDropLocations()
-  const isItemVisibleForClasses = useIsItemVisibleForClasses()
-
   const activeSetup: GearSetup = useMemo(() => {
     return (
       setups.find((s: GearSetup) => s.id === activeSetupId) ??
@@ -73,6 +70,47 @@ const useGearPlanner = (props: Props) => {
     )
   }, [activeSetupId, setups])
   const { artificerPet, druidPet } = activeSetup
+  const formatDropLocations = useFormatDropLocations()
+  const isItemVisibleForClasses = useIsItemVisibleForClasses()
+  const [collapsedItemCards, setCollapsedItemCards] = useState<Record<string, boolean>>({})
+  const currentItemIds = useMemo(() => {
+    const ids = new Set<string>()
+
+    for (const item of Object.values(activeSetup.slots)) {
+      if (item) ids.add(item.id)
+    }
+
+    for (const item of Object.values(activeSetup.artificerPet.slots)) {
+      if (item) ids.add(item.id)
+    }
+
+    for (const item of Object.values(activeSetup.druidPet.slots)) {
+      if (item) ids.add(item.id)
+    }
+
+    return [...ids]
+  }, [activeSetup.artificerPet.slots, activeSetup.druidPet.slots, activeSetup.slots])
+  const isItemCardCollapsed = useCallback((itemId: string) => collapsedItemCards[itemId] ?? false, [collapsedItemCards])
+  const toggleItemCardCollapsed = useCallback((itemId: string) => {
+    setCollapsedItemCards((prev) => ({
+      ...prev,
+      [itemId]: !prev[itemId]
+    }))
+  }, [])
+  const setAllItemCardsCollapsed = useCallback(
+    (collapsed: boolean) => {
+      setCollapsedItemCards((prev) => {
+        const next = { ...prev }
+        for (const itemId of currentItemIds) {
+          next[itemId] = collapsed
+        }
+        return next
+      })
+    },
+    [currentItemIds]
+  )
+  const allItemCardsCollapsed =
+    currentItemIds.length > 0 && currentItemIds.every((itemId) => collapsedItemCards[itemId])
   const activeSetupWithUpgradeViews: GearSetup & UpgradeViews = useMemo(() => {
     return {
       ...activeSetup,
@@ -138,7 +176,11 @@ const useGearPlanner = (props: Props) => {
     setFountainOfNecroticMight: actions.setFountainOfNecroticMight,
     setStormreaverUpgrade: actions.setStormreaverUpgrade,
     setZhentarimAttuned: actions.setZhentarimAttuned,
-    setReaperForge: actions.setReaperForge
+    setReaperForge: actions.setReaperForge,
+    isItemCardCollapsed,
+    toggleItemCardCollapsed,
+    allItemCardsCollapsed,
+    setAllItemCardsCollapsed
   })
 
   const observerRef = useRef<IntersectionObserver | null>(null)
@@ -225,6 +267,8 @@ const useGearPlanner = (props: Props) => {
     showOwnedOnly,
     showSetBonusBrowser,
     showSidebar,
+    allItemCardsCollapsed,
+    setAllItemCardsCollapsed,
     updateClassProficiencies: actions.updateClassProficiencies
   }
 }

--- a/src/pages/gearPlanner/hooks/useGearPlanner.tsx
+++ b/src/pages/gearPlanner/hooks/useGearPlanner.tsx
@@ -16,6 +16,24 @@ interface Props {
   enchantmentBonusType: string
 }
 
+const collectSetupItemIds = (setup: GearSetup) => {
+  const ids = new Set<string>()
+
+  for (const item of Object.values(setup.slots)) {
+    if (item) ids.add(item.id)
+  }
+
+  for (const item of Object.values(setup.artificerPet.slots)) {
+    if (item) ids.add(item.id)
+  }
+
+  for (const item of Object.values(setup.druidPet.slots)) {
+    if (item) ids.add(item.id)
+  }
+
+  return [...ids]
+}
+
 const useGearPlanner = (props: Props) => {
   const { characterSetups: setups, activeSetupId } = useAppSelector((state) => state.gearPlanner)
 
@@ -73,23 +91,7 @@ const useGearPlanner = (props: Props) => {
   const formatDropLocations = useFormatDropLocations()
   const isItemVisibleForClasses = useIsItemVisibleForClasses()
   const [collapsedItemCards, setCollapsedItemCards] = useState<Record<string, boolean>>({})
-  const currentItemIds = useMemo(() => {
-    const ids = new Set<string>()
-
-    for (const item of Object.values(activeSetup.slots)) {
-      if (item) ids.add(item.id)
-    }
-
-    for (const item of Object.values(activeSetup.artificerPet.slots)) {
-      if (item) ids.add(item.id)
-    }
-
-    for (const item of Object.values(activeSetup.druidPet.slots)) {
-      if (item) ids.add(item.id)
-    }
-
-    return [...ids]
-  }, [activeSetup.artificerPet.slots, activeSetup.druidPet.slots, activeSetup.slots])
+  const currentItemIds = useMemo(() => collectSetupItemIds(activeSetup), [activeSetup])
   const isItemCardCollapsed = useCallback((itemId: string) => collapsedItemCards[itemId] ?? false, [collapsedItemCards])
   const toggleItemCardCollapsed = useCallback((itemId: string) => {
     setCollapsedItemCards((prev) => ({
@@ -111,6 +113,9 @@ const useGearPlanner = (props: Props) => {
   )
   const allItemCardsCollapsed =
     currentItemIds.length > 0 && currentItemIds.every((itemId) => collapsedItemCards[itemId])
+  const toggleAllItemCardsCollapsed = useCallback(() => {
+    setAllItemCardsCollapsed(!allItemCardsCollapsed)
+  }, [allItemCardsCollapsed, setAllItemCardsCollapsed])
   const activeSetupWithUpgradeViews: GearSetup & UpgradeViews = useMemo(() => {
     return {
       ...activeSetup,
@@ -179,8 +184,7 @@ const useGearPlanner = (props: Props) => {
     setReaperForge: actions.setReaperForge,
     isItemCardCollapsed,
     toggleItemCardCollapsed,
-    allItemCardsCollapsed,
-    setAllItemCardsCollapsed
+    allItemCardsCollapsed
   })
 
   const observerRef = useRef<IntersectionObserver | null>(null)
@@ -269,6 +273,7 @@ const useGearPlanner = (props: Props) => {
     showSidebar,
     allItemCardsCollapsed,
     setAllItemCardsCollapsed,
+    toggleAllItemCardsCollapsed,
     updateClassProficiencies: actions.updateClassProficiencies
   }
 }


### PR DESCRIPTION
- **GearPlanner.css**: Styled headers and collapse buttons for item cards.
- **GearPlanner.tsx**: Added `onToggleCollapseAll` handler for items.
- **SetupTabs.tsx**: Integrated "Collapse All" button into setup tabs.
- **useGearPlanner.tsx**: Implemented state logic for collapsing item cards.
- **renderGearPlanner.tsx**: Updated card rendering to respect collapse state.